### PR TITLE
Add non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends nfs-common && \
 RUN mkdir -p /home/ibm-csi-drivers/
 ADD ibm-vpc-block-csi-driver /home/ibm-csi-drivers
 RUN chmod +x /home/ibm-csi-drivers/ibm-vpc-block-csi-driver
-
+USER 2121:2121
 
 ENTRYPOINT ["/home/ibm-csi-drivers/ibm-vpc-block-csi-driver"]


### PR DESCRIPTION
```
# git commit -m "Add non-root user"
Detect secrets...........................................................Passed
[ubuuser 1cc1a5c] Add non-root user
 1 file changed, 1 insertion(+), 1 deletion(-)
root@devmachine1:~/WORKSPACE/src/github.com/IBM/ibm-vpc-block-csi-driver# git push
fatal: The current branch ubuuser has no upstream branch.
To push the current branch and set the remote as upstream, use
```
`Test Results`

```
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl exec -it ibm-vpc-block-csi-controller-0   -n kube-system -c iks-vpc-block-driver /bin/bash 
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
2121@ibm-vpc-block-csi-controller-0:/$ who
2121@ibm-vpc-block-csi-controller-0:/$ id 
uid=2121(2121) gid=0(root) groups=0(root)
2121@ibm-vpc-block-csi-controller-0:/$ 

ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % oc get pods -n kube-system | grep block
ibm-vpc-block-csi-controller-0         5/5     Running             0          13s
ibm-vpc-block-csi-node-49d29           3/3     Running             0          12s
ibm-vpc-block-csi-node-bwftc           3/3     Running             0          12s
ibm-vpc-block-csi-node-rkr2j           0/3     ContainerCreating   0          12s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl exec -it ibm-vpc-block-csi-controller-0   -n kube-system
error: you must specify at least one command for the container
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl exec -it ibm-vpc-block-csi-controller-0   -n kube-system -c iks-vpc-block-driver
error: you must specify at least one command for the container
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl exec -it ibm-vpc-block-csi-controller-0   -n kube-system -c iks-vpc-block-driver /bin/bash 
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
2121@ibm-vpc-block-csi-controller-0:/$ who
2121@ibm-vpc-block-csi-controller-0:/$ id 
uid=2121(2121) gid=0(root) groups=0(root)
2121@ibm-vpc-block-csi-controller-0:/$ exit
exit
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods
NAME                           READY   STATUS    RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running   0          3d3h
web-0                          1/1     Running   0          3d3h
web-1                          1/1     Running   0          3d3h
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl delete -f stateful.yaml 
service "nginx" deleted
statefulset.apps "web" deleted
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pvc
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
test-enc    Bound    pvc-74c7eaaf-bee3-4897-b129-2a5a4c6ab79f   56Gi       RWO            ibmc-vpc-block-retain-5iops-tier1   3d3h
www-web-0   Bound    pvc-7bb75c41-65ef-4900-a54c-9f9c46cd6fa5   25Gi       RWO            ibmc-vpc-block-5iops-tier           4d2h
www-web-1   Bound    pvc-73c0a966-2cf5-4f35-8ee8-200613990669   25Gi       RWO            ibmc-vpc-block-5iops-tier           4d2h
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl delete pvc www-web-0  www-web-1 
persistentvolumeclaim "www-web-0" deleted
persistentvolumeclaim "www-web-1" deleted
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl create -f stateful.yaml 
service/nginx created
statefulset.apps/web created
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pvc
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                        AGE
test-enc    Bound    pvc-74c7eaaf-bee3-4897-b129-2a5a4c6ab79f   56Gi       RWO            ibmc-vpc-block-retain-5iops-tier1   3d3h
www-web-0   Bound    pvc-d401527a-b421-4cbb-a7e9-4429c40518bc   25Gi       RWO            ibmc-vpc-block-5iops-tier           43s
www-web-1   Bound    pvc-4e490460-3808-4f1b-9f7d-8092bbc84e3d   25Gi       RWO            ibmc-vpc-block-5iops-tier           43s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods 
NAME                           READY   STATUS              RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running             0          3d3h
web-0                          0/1     ContainerCreating   0          49s
web-1                          0/1     ContainerCreating   0          49s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % vi stateful.yaml 
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % vi stateful.yaml
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods
NAME                           READY   STATUS              RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running             0          3d3h
web-0                          0/1     ContainerCreating   0          68s
web-1                          0/1     ContainerCreating   0          68s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl describe pod web-0 
Name:           web-0
Namespace:      default
Priority:       0
Node:           10.240.64.38/10.240.64.38
Start Time:     Mon, 26 Jul 2021 15:16:06 +0530
Labels:         app=nginx
                controller-revision-hash=web-66567d9484
                statefulset.kubernetes.io/pod-name=web-0
Annotations:    <none>
Status:         Pending
IP:             
IPs:            <none>
Controlled By:  StatefulSet/web
Containers:
  nginx:
    Container ID:   
    Image:          k8s.gcr.io/nginx-slim:0.8
    Image ID:       
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /usr/share/nginx/html from www (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-9r57t (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             False 
  ContainersReady   False 
  PodScheduled      True 
Volumes:
  www:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  www-web-0
    ReadOnly:   false
  default-token-9r57t:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-9r57t
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason            Age   From               Message
  ----     ------            ----  ----               -------
  Warning  FailedScheduling  77s   default-scheduler  0/3 nodes are available: 3 pod has unbound immediate PersistentVolumeClaims.
  Warning  FailedScheduling  77s   default-scheduler  0/3 nodes are available: 3 pod has unbound immediate PersistentVolumeClaims.
  Normal   Scheduled         38s   default-scheduler  Successfully assigned default/web-0 to 10.240.64.38
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods           
NAME                           READY   STATUS              RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running             0          3d3h
web-0                          0/1     ContainerCreating   0          84s
web-1                          0/1     ContainerCreating   0          84s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods
NAME                           READY   STATUS              RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running             0          3d3h
web-0                          0/1     ContainerCreating   0          94s
web-1                          0/1     ContainerCreating   0          94s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl describe pod web-0 
Name:           web-0
Namespace:      default
Priority:       0
Node:           10.240.64.38/10.240.64.38
Start Time:     Mon, 26 Jul 2021 15:16:06 +0530
Labels:         app=nginx
                controller-revision-hash=web-66567d9484
                statefulset.kubernetes.io/pod-name=web-0
Annotations:    <none>
Status:         Pending
IP:             
IPs:            <none>
Controlled By:  StatefulSet/web
Containers:
  nginx:
    Container ID:   
    Image:          k8s.gcr.io/nginx-slim:0.8
    Image ID:       
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /usr/share/nginx/html from www (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-9r57t (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             False 
  ContainersReady   False 
  PodScheduled      True 
Volumes:
  www:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  www-web-0
    ReadOnly:   false
  default-token-9r57t:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-9r57t
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason                  Age   From                     Message
  ----     ------                  ----  ----                     -------
  Warning  FailedScheduling        99s   default-scheduler        0/3 nodes are available: 3 pod has unbound immediate PersistentVolumeClaims.
  Warning  FailedScheduling        99s   default-scheduler        0/3 nodes are available: 3 pod has unbound immediate PersistentVolumeClaims.
  Normal   Scheduled               60s   default-scheduler        Successfully assigned default/web-0 to 10.240.64.38
  Normal   SuccessfulAttachVolume  19s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-d401527a-b421-4cbb-a7e9-4429c40518bc"
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods           
NAME                           READY   STATUS              RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running             0          3d3h
web-0                          0/1     ContainerCreating   0          104s
web-1                          0/1     ContainerCreating   0          104s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl get pods
NAME                           READY   STATUS    RESTARTS   AGE
testpodrwo8-5897c45796-4fnv7   1/1     Running   0          3d3h
web-0                          1/1     Running   0          2m51s
web-1                          1/1     Running   0          2m51s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl exec -it web-o sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Error from server (NotFound): pods "web-o" not found
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % kubectl exec -it web-0 sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
# ls /usr/share/nginx/html
lost+found
# echo"hi" > /usr/share/nginx/html/new.txt
sh: 2: echohi: not found
# echo "hi"  > /usr/share/nginx/html/new.txt
# cat  /usr/share/nginx/html/new.txt
hi
# mount
sh: 5: mount: not found
# exit
command terminated with exit code 127

@ambiknai
Member Author
ambiknai commented 3 minutes ago

ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % oc get pods -n kube-system | grep block
ibm-vpc-block-csi-controller-0         5/5     Running   0          7m42s
ibm-vpc-block-csi-node-49d29           3/3     Running   0          7m41s
ibm-vpc-block-csi-node-bwftc           3/3     Running   0          7m41s
ibm-vpc-block-csi-node-rkr2j           3/3     Running   0          7m41s
ambikanair@Ambika-Nairs-MacBook-Pro ibm-vpc-block-csi-driver % oc describe pod -n kube-system ibm-vpc-block-csi-controller-0 
Name:         ibm-vpc-block-csi-controller-0
Namespace:    kube-system
Priority:     0
Node:         10.240.64.40/10.240.64.40
Start Time:   Mon, 26 Jul 2021 15:13:16 +0530
Labels:       app=ibm-vpc-block-csi-driver
              controller-revision-hash=ibm-vpc-block-csi-controller-6b7fd4b544
              statefulset.kubernetes.io/pod-name=ibm-vpc-block-csi-controller-0
Annotations:  cni.projectcalico.org/podIP: 172.22.2.146/32
              cni.projectcalico.org/podIPs: 172.22.2.146/32
              k8s.v1.cni.cncf.io/network-status:
                [{
                    "name": "",
                    "ips": [
                        "172.22.2.146"
                    ],
                    "default": true,
                    "dns": {}
                }]
              k8s.v1.cni.cncf.io/networks-status:
                [{
                    "name": "",
                    "ips": [
                        "172.22.2.146"
                    ],
                    "default": true,
                    "dns": {}
                }]
              prometheus.io/path: /metrics
              prometheus.io/port: 9080
              prometheus.io/scrape: true
Status:       Running
IP:           172.22.2.146
IPs:
  IP:           172.22.2.146
Controlled By:  StatefulSet/ibm-vpc-block-csi-controller
Containers:
  csi-provisioner:
    Container ID:  cri-o://9af5c3a55f6ad723b11c5681fc3065d74dc8953177148366750cf93312d37136
    Image:         quay.io/k8scsi/csi-provisioner:v1.6.0
    Image ID:      quay.io/k8scsi/csi-provisioner@sha256:78e3393f5fd5ff6c1e5dada2478cfa456fb7164929e573cf9a87bf6532730679
    Port:          <none>
    Host Port:     <none>
    Args:
      --v=5
      --csi-address=$(ADDRESS)
      --timeout=600s
      --feature-gates=Topology=true
    State:          Running
      Started:      Mon, 26 Jul 2021 15:13:18 +0530
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  100Mi
    Requests:
      cpu:     10m
      memory:  20Mi
    Environment:
      ADDRESS:  /csi/csi.sock
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from ibm-vpc-block-controller-sa-token-rq588 (ro)
  csi-attacher:
    Container ID:  cri-o://abbdda27bc0454e68347a2f7655dd2e5b8b5c3fb431664c1bd495810fca1883a
    Image:         quay.io/k8scsi/csi-attacher:v2.2.0
    Image ID:      quay.io/k8scsi/csi-attacher@sha256:2ffa647e8107cfd39e5f464e738dce014c9f5e51b108da36c3ab621048d0bbab
    Port:          <none>
    Host Port:     <none>
    Args:
      --v=5
      --csi-address=/csi/csi.sock
      --timeout=900s
    State:          Running
      Started:      Mon, 26 Jul 2021 15:13:18 +0530
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  100Mi
    Requests:
      cpu:        10m
      memory:     20Mi
    Environment:  <none>
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from ibm-vpc-block-controller-sa-token-rq588 (ro)
  liveness-probe:
    Container ID:  cri-o://ede000ceba8b592117140bf9bc686ac1a8856fbf895e5a282a0dcacc6703ecfc
    Image:         quay.io/k8scsi/livenessprobe:v2.0.0
    Image ID:      quay.io/k8scsi/livenessprobe@sha256:320d8e40670205477e3fbc7bfb95567dc3829ec824bc4ed8163ade9e046de694
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=/csi/csi.sock
    State:          Running
      Started:      Mon, 26 Jul 2021 15:13:19 +0530
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     50m
      memory:  50Mi
    Requests:
      cpu:        5m
      memory:     10Mi
    Environment:  <none>
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from ibm-vpc-block-controller-sa-token-rq588 (ro)
  iks-vpc-block-driver:
    Container ID:  cri-o://f9963c3ad957c1f6f5fccc2e3640ef4abf488ac4041804fc8737ba1f67f7e7f1
    Image:         ambikanair/ibm-vpc-block-csi-driver:ubicsiimage
    Image ID:      docker.io/ambikanair/ibm-vpc-block-csi-driver@sha256:61a378a01ed15932dc5530f21eecc717ff6c7ced84ae00a981392dcae19c786d
    Port:          9808/TCP
    Host Port:     0/TCP
    Args:
      --v=5
      --endpoint=$(CSI_ENDPOINT)
      --lock_enabled=false
    State:          Running
      Started:      Mon, 26 Jul 2021 15:13:24 +0530
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     500m
      memory:  500Mi
    Requests:
      cpu:     50m
      memory:  100Mi
    Liveness:  http-get http://:healthz/healthz delay=10s timeout=3s period=10s #success=1 #failure=5
    Environment Variables from:
      ibm-vpc-block-csi-configmap  ConfigMap  Optional: false
    Environment:
      POD_NAME:       ibm-vpc-block-csi-controller-0 (v1:metadata.name)
      POD_NAMESPACE:  kube-system (v1:metadata.namespace)
    Mounts:
      /csi from socket-dir (rw)
      /etc/storage_ibmc from customer-auth (ro)
      /etc/storage_ibmc/cluster_info from cluster-info (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from ibm-vpc-block-controller-sa-token-rq588 (ro)
  csi-resizer:
    Container ID:  cri-o://cff83cef2b900a250b16a6931b044ef13390384207590f484160ab930e3007f8
    Image:         quay.io/k8scsi/csi-resizer:v1.0.0
    Image ID:      quay.io/k8scsi/csi-resizer@sha256:83655a67f84ac500b67fd0e7084d1eaa9828321d179269171aa0c9bc35ca8ef9
    Port:          <none>
    Host Port:     <none>
    Args:
      --v=5
      --csi-address=$(ADDRESS)
      --timeout=600s
    State:          Running
      Started:      Mon, 26 Jul 2021 15:13:26 +0530
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  100Mi
    Requests:
      cpu:     10m
      memory:  20Mi
    Environment:
      ADDRESS:  /csi/csi.sock
    Mounts:
      /csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from ibm-vpc-block-controller-sa-token-rq588 (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  socket-dir:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     
    SizeLimit:  <unset>
  customer-auth:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  storage-secret-store
    Optional:    false
  cluster-info:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      cluster-info
    Optional:  false
  ibm-vpc-block-controller-sa-token-rq588:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  ibm-vpc-block-controller-sa-token-rq588
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason          Age    From               Message
  ----    ------          ----   ----               -------
  Normal  Scheduled       7m53s  default-scheduler  Successfully assigned kube-system/ibm-vpc-block-csi-controller-0 to 10.240.64.40
  Normal  AddedInterface  7m52s  multus             Add eth0 [172.22.2.146/32]
  Normal  Pulling         7m52s  kubelet            Pulling image "quay.io/k8scsi/csi-provisioner:v1.6.0"
  Normal  Pulled          7m52s  kubelet            Successfully pulled image "quay.io/k8scsi/csi-provisioner:v1.6.0" in 554.754238ms
  Normal  Pulled          7m51s  kubelet            Container image "quay.io/k8scsi/csi-attacher:v2.2.0" already present on machine
  Normal  Started         7m51s  kubelet            Started container csi-provisioner
  Normal  Created         7m51s  kubelet            Created container csi-attacher
  Normal  Started         7m51s  kubelet            Started container csi-attacher
  Normal  Pulled          7m51s  kubelet            Container image "quay.io/k8scsi/livenessprobe:v2.0.0" already present on machine
  Normal  Created         7m51s  kubelet            Created container csi-provisioner
  Normal  Pulling         7m50s  kubelet            Pulling image "ambikanair/ibm-vpc-block-csi-driver:ubicsiimage"
  Normal  Started         7m50s  kubelet            Started container liveness-probe
  Normal  Created         7m50s  kubelet            Created container liveness-probe
  Normal  Pulled          7m45s  kubelet            Successfully pulled image "ambikanair/ibm-vpc-block-csi-driver:ubicsiimage" in 5.186301134s
  Normal  Created         7m45s  kubelet            Created container iks-vpc-block-driver
  Normal  Started         7m45s  kubelet            Started container iks-vpc-block-driver
  Normal  Pulling         7m45s  kubelet            Pulling image "quay.io/k8scsi/csi-resizer:v1.0.0"
  Normal  Pulled          7m43s  kubelet            Successfully pulled image "quay.io/k8scsi/csi-resizer:v1.0.0" in 1.448627937s
  Normal  Created         7m43s  kubelet            Created container csi-resizer
  Normal  Started         7m43s  kubelet            Started container csi-resizer
```