### PR TITLE
Fix go build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ lint:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
+	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=mod -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
 
 .PHONY: test
 test:


### PR DESCRIPTION
`Test Results`

```
# export GOPATH=/root/WORKSPACE/
root@devmachine1:~/WORKSPACE/src/github.com/IBM/ibm-vpc-block-csi-driver# git status
On branch build
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   Makefile

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	cover.out
	ibm-vpc-block-csi-driver

no changes added to commit (use "git add" and/or "git commit -a")
root@devmachine1:~/WORKSPACE/src/github.com/IBM/ibm-vpc-block-csi-driver# make
echo "Installing dependencies ..."
Installing dependencies ...
#glide install --strip-vendor
go mod download
go get github.com/pierrre/gotestcover
/bin/sh: 1: [[: not found
golangci-lint run --timeout 600s
golangci-lint run --disable-all --enable=gofmt --timeout 600s
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=mod -a -ldflags '-X main.vendorVersion='"vpcBlockDriver-"fef39458ca46a85061e09df0648a06ae1f86a1ed""' -extldflags "-static"' -o /root/WORKSPACE//bin/ibm-vpc-block-csi-driver ./cmd/
/root/WORKSPACE//bin/gotestcover -v -race -short -coverprofile=cover.out github.com/IBM/ibm-vpc-block-csi-driver/config github.com/IBM/ibm-vpc-block-csi-driver/pkg/ibmcsidriver
?   	github.com/IBM/ibm-vpc-block-csi-driver/config	[no test files]
=== RUN   TestGetRequestedCapacity
=== RUN   TestGetRequestedCapacity/Check_minimum_size_supported_by_volume_provider_in_case_of_nil_passed_as_input
=== RUN   TestGetRequestedCapacity/Capacity_range_is_nil
=== RUN   TestGetRequestedCapacity/Check_minimum_size_supported_by_volume_provider
=== RUN   TestGetRequestedCapacity/Check_size_passed_as_actual_value
=== RUN   TestGetRequestedCapacity/Expected_error_check-success
=== RUN   TestGetRequestedCapacity/Expected_error_check_against_limit_byte-success
--- PASS: TestGetRequestedCapacity (0.00s)
    --- PASS: TestGetRequestedCapacity/Check_minimum_size_supported_by_volume_provider_in_case_of_nil_passed_as_input (0.00s)
    --- PASS: TestGetRequestedCapacity/Capacity_range_is_nil (0.00s)
    --- PASS: TestGetRequestedCapacity/Check_minimum_size_supported_by_volume_provider (0.00s)
    --- PASS: TestGetRequestedCapacity/Check_size_passed_as_actual_value (0.00s)
    --- PASS: TestGetRequestedCapacity/Expected_error_check-success (0.00s)
    --- PASS: TestGetRequestedCapacity/Expected_error_check_against_limit_byte-success (0.00s)
=== RUN   TestAreVolumeCapabilitiesSupported
=== RUN   TestAreVolumeCapabilitiesSupported/Supported_volume_capability-success
=== RUN   TestAreVolumeCapabilitiesSupported/Unsupported_volume_capability
--- PASS: TestAreVolumeCapabilitiesSupported (0.01s)
    --- PASS: TestAreVolumeCapabilitiesSupported/Supported_volume_capability-success (0.00s)
    --- PASS: TestAreVolumeCapabilitiesSupported/Unsupported_volume_capability (0.00s)
=== RUN   TestGetVolumeParameters
=== RUN   TestGetVolumeParameters/Valid_create_volume_request-success
=== RUN   TestGetVolumeParameters/Wrong_profile_name
=== RUN   TestGetVolumeParameters/Max_length_exceeded_for_zone_name
=== RUN   TestGetVolumeParameters/Max_length_exceeded_for_region_name
=== RUN   TestGetVolumeParameters/Max_length_exceeded_for_resource_group_ID
=== RUN   TestGetVolumeParameters/Max_length_exceeded_for_tag
=== RUN   TestGetVolumeParameters/Wrong_encrypted_key's_value
=== RUN   TestGetVolumeParameters/Max_length_exceeded_for_encryption_key
=== RUN   TestGetVolumeParameters/Unsupported_parameter
=== RUN   TestGetVolumeParameters/Invalid_capacity_range
=== RUN   TestGetVolumeParameters/Override_parameter_with_secrets-wrong_secret_parameter
=== RUN   TestGetVolumeParameters/Empty_volume_capabilities
--- PASS: TestGetVolumeParameters (0.01s)
    --- PASS: TestGetVolumeParameters/Valid_create_volume_request-success (0.00s)
    --- PASS: TestGetVolumeParameters/Wrong_profile_name (0.00s)
    --- PASS: TestGetVolumeParameters/Max_length_exceeded_for_zone_name (0.00s)
    --- PASS: TestGetVolumeParameters/Max_length_exceeded_for_region_name (0.00s)
    --- PASS: TestGetVolumeParameters/Max_length_exceeded_for_resource_group_ID (0.00s)
    --- PASS: TestGetVolumeParameters/Max_length_exceeded_for_tag (0.00s)
    --- PASS: TestGetVolumeParameters/Wrong_encrypted_key's_value (0.00s)
    --- PASS: TestGetVolumeParameters/Max_length_exceeded_for_encryption_key (0.00s)
    --- PASS: TestGetVolumeParameters/Unsupported_parameter (0.00s)
    --- PASS: TestGetVolumeParameters/Invalid_capacity_range (0.00s)
    --- PASS: TestGetVolumeParameters/Override_parameter_with_secrets-wrong_secret_parameter (0.00s)
    --- PASS: TestGetVolumeParameters/Empty_volume_capabilities (0.00s)
=== RUN   TestIsValidCapacityIOPS4CustomClass
=== RUN   TestIsValidCapacityIOPS4CustomClass/Valid_capacity_IOPS
=== RUN   TestIsValidCapacityIOPS4CustomClass/Invalid_capacity
=== RUN   TestIsValidCapacityIOPS4CustomClass/Invalid_IOPS
--- PASS: TestIsValidCapacityIOPS4CustomClass (0.00s)
    --- PASS: TestIsValidCapacityIOPS4CustomClass/Valid_capacity_IOPS (0.00s)
    --- PASS: TestIsValidCapacityIOPS4CustomClass/Invalid_capacity (0.00s)
    --- PASS: TestIsValidCapacityIOPS4CustomClass/Invalid_IOPS (0.00s)
=== RUN   TestOverrideParams
=== RUN   TestOverrideParams/Valid_overwrite-success
=== RUN   TestOverrideParams/Secret_wrong_encrypted_value
=== RUN   TestOverrideParams/Resource_group_ID_size_exceeded
=== RUN   TestOverrideParams/Encryption_key_size_exceeded
=== RUN   TestOverrideParams/Tag_key_size_exceeded
=== RUN   TestOverrideParams/Zone_key_size_exceeded
=== RUN   TestOverrideParams/Region_key_size_exceeded
=== RUN   TestOverrideParams/Valid_IOPS_for_custom_class
=== RUN   TestOverrideParams/Secret_invalid_IOPS_for_custom_class
=== RUN   TestOverrideParams/Nil_volume_as_input/output
--- PASS: TestOverrideParams (0.00s)
    --- PASS: TestOverrideParams/Valid_overwrite-success (0.00s)
    --- PASS: TestOverrideParams/Secret_wrong_encrypted_value (0.00s)
    --- PASS: TestOverrideParams/Resource_group_ID_size_exceeded (0.00s)
    --- PASS: TestOverrideParams/Encryption_key_size_exceeded (0.00s)
    --- PASS: TestOverrideParams/Tag_key_size_exceeded (0.00s)
    --- PASS: TestOverrideParams/Zone_key_size_exceeded (0.00s)
    --- PASS: TestOverrideParams/Region_key_size_exceeded (0.00s)
    --- PASS: TestOverrideParams/Valid_IOPS_for_custom_class (0.00s)
    --- PASS: TestOverrideParams/Secret_invalid_IOPS_for_custom_class (0.00s)
    --- PASS: TestOverrideParams/Nil_volume_as_input/output (0.00s)
=== RUN   TestCheckIfVolumeExists
--- PASS: TestCheckIfVolumeExists (0.00s)
=== RUN   TestCreateCSIVolumeResponse
=== RUN   TestCreateCSIVolumeResponse/Valid_volume_response
--- PASS: TestCreateCSIVolumeResponse (0.00s)
    --- PASS: TestCreateCSIVolumeResponse/Valid_volume_response (0.00s)
=== RUN   TestCreateControllerPublishVolumeResponse
=== RUN   TestCreateControllerPublishVolumeResponse/Valid_controller_volume_response
--- PASS: TestCreateControllerPublishVolumeResponse (0.00s)
    --- PASS: TestCreateControllerPublishVolumeResponse/Valid_controller_volume_response (0.00s)
=== RUN   TestPickTargetTopologyParams
=== RUN   TestPickTargetTopologyParams/Valid_pick_target_for_topology
=== RUN   TestPickTargetTopologyParams/Nil_pick_target_for_topology
--- PASS: TestPickTargetTopologyParams (0.00s)
    --- PASS: TestPickTargetTopologyParams/Valid_pick_target_for_topology (0.00s)
    --- PASS: TestPickTargetTopologyParams/Nil_pick_target_for_topology (0.00s)
=== RUN   TestGetPrefedTopologyParams
=== RUN   TestGetPrefedTopologyParams/Valid_preferred_topology_params
=== RUN   TestGetPrefedTopologyParams/With_nil_preferred_topology_params
--- PASS: TestGetPrefedTopologyParams (0.00s)
    --- PASS: TestGetPrefedTopologyParams/Valid_preferred_topology_params (0.00s)
    --- PASS: TestGetPrefedTopologyParams/With_nil_preferred_topology_params (0.00s)
=== RUN   TestCreateVolumeArguments
    controller_test.go:207: test case: Success default
{"level":"info","ts":"2021-07-29T02:04:03.211-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"73d28340-6509-43e7-a39a-b9a3bf91967c","Request":{"name":"test-name","capacity_range":{"required_bytes":21474836480},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}],"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"info","ts":"2021-07-29T02:04:03.212-0700","caller":"ibmcsidriver/controller_helper.go:214","msg":"Volume size in bytes","RequestID":"73d28340-6509-43e7-a39a-b9a3bf91967c","capacity":21474836480}
{"level":"info","ts":"2021-07-29T02:04:03.212-0700","caller":"ibmcsidriver/controller_helper.go:220","msg":"Volume size in GiB","RequestID":"73d28340-6509-43e7-a39a-b9a3bf91967c","capacity":20}
{"level":"info","ts":"2021-07-29T02:04:03.212-0700","caller":"ibmcsidriver/controller.go:95","msg":"Volume request after masking encryption key","RequestID":"73d28340-6509-43e7-a39a-b9a3bf91967c","Volume":{"provider":"","volumeType":"ext2","capacity":20,"iops":null,"tier":null,"region":"myregion","az":"myzone","creationTime":"0001-01-01T00:00:00Z","name":"test-name","resource_group":{},"encryption_key":{"crn":"********"},"profile":{"name":"general-purpose"}}}
{"level":"info","ts":"2021-07-29T02:04:03.213-0700","caller":"ibmcsidriver/controller.go:113","msg":"Volume already exists","RequestID":"73d28340-6509-43e7-a39a-b9a3bf91967c","ExistingVolume":{"volumeID":"testVolumeId","provider":"","volumeType":"","capacity":20,"iops":"","tier":null,"region":"myregion","az":"myzone","creationTime":"0001-01-01T00:00:00Z","name":"test-name"}}
{"level":"info","ts":"2021-07-29T02:04:03.213-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"73d28340-6509-43e7-a39a-b9a3bf91967c","CreateVolume":0.001503059}
    controller_test.go:207: test case: Empty volume name
{"level":"info","ts":"2021-07-29T02:04:03.214-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"401e2e79-c7f8-4a50-8afb-cf73e65c24ca","Request":{"capacity_range":{"required_bytes":21474836480},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}],"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"error","ts":"2021-07-29T02:04:03.215-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"401e2e79-c7f8-4a50-8afb-cf73e65c24ca","error":"{RequestID: 401e2e79-c7f8-4a50-8afb-cf73e65c24ca , Code: MissingVolumeName, Description: Volume name not provided, Action: Please provide volume name while creating volume}"}
{"level":"info","ts":"2021-07-29T02:04:03.215-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"401e2e79-c7f8-4a50-8afb-cf73e65c24ca","CreateVolume":0.00018765}
    controller_test.go:207: test case: Empty volume capabilities
{"level":"info","ts":"2021-07-29T02:04:03.216-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"e2385494-0441-497c-b7d5-fb9d4962d13c","Request":{"name":"test-name","capacity_range":{"required_bytes":21474836480},"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"error","ts":"2021-07-29T02:04:03.216-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"e2385494-0441-497c-b7d5-fb9d4962d13c","error":"{RequestID: e2385494-0441-497c-b7d5-fb9d4962d13c , Code: NoVolumeCapabilities, Description: Volume capabilities must be provided, Action: Please provide volume capabilities in the storage class before creating volume}"}
{"level":"info","ts":"2021-07-29T02:04:03.216-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"e2385494-0441-497c-b7d5-fb9d4962d13c","CreateVolume":0.000111999}
    controller_test.go:207: test case: Not supported volume Capabilities
{"level":"info","ts":"2021-07-29T02:04:03.217-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"4c8ba8e0-96b4-4bbb-901e-edcdde4bae3a","Request":{"name":"test-name","capacity_range":{"required_bytes":21474836480},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":5}}],"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"error","ts":"2021-07-29T02:04:03.217-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"4c8ba8e0-96b4-4bbb-901e-edcdde4bae3a","error":"{RequestID: 4c8ba8e0-96b4-4bbb-901e-edcdde4bae3a , Code: VolumeCapabilitiesNotSupported, Description: Volume capabilities not supported, Action: Please provide valid volume capabilities while creating volume}"}
{"level":"info","ts":"2021-07-29T02:04:03.217-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"4c8ba8e0-96b4-4bbb-901e-edcdde4bae3a","CreateVolume":0.000140703}
    controller_test.go:207: test case: ProvisioningFailed lib error form create volume
{"level":"info","ts":"2021-07-29T02:04:03.218-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","Request":{"name":"test-name","capacity_range":{"required_bytes":21474836480},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}],"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"info","ts":"2021-07-29T02:04:03.218-0700","caller":"ibmcsidriver/controller_helper.go:214","msg":"Volume size in bytes","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","capacity":21474836480}
{"level":"info","ts":"2021-07-29T02:04:03.219-0700","caller":"ibmcsidriver/controller_helper.go:220","msg":"Volume size in GiB","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","capacity":20}
{"level":"info","ts":"2021-07-29T02:04:03.219-0700","caller":"ibmcsidriver/controller.go:95","msg":"Volume request after masking encryption key","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","Volume":{"provider":"","volumeType":"ext2","capacity":20,"iops":null,"tier":null,"region":"myregion","az":"myzone","creationTime":"0001-01-01T00:00:00Z","name":"test-name","resource_group":{},"encryption_key":{"crn":"********"},"profile":{"name":"general-purpose"}}}
{"level":"error","ts":"2021-07-29T02:04:03.219-0700","caller":"ibmcsidriver/controller_helper.go:404","msg":"checkIfVolumeExists","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","Error":"{Code:FailedToPlaceOrder, Type:ProvisioningFailed, Description:Volume creation failed, BackendError:, RC:0}"}
{"level":"error","ts":"2021-07-29T02:04:03.219-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","error":"{RequestID: b11d940a-8a60-4d74-baab-5e625c03fa2a , Code: InternalError, Description: Internal error occurred%!(EXTRA string=creation), BackendError: {Code:FailedToPlaceOrder, Type:ProvisioningFailed, Description:Volume creation failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.219-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"b11d940a-8a60-4d74-baab-5e625c03fa2a","CreateVolume":0.000481675}
    controller_test.go:207: test case: InvalidRequest lib error form create volume
{"level":"info","ts":"2021-07-29T02:04:03.220-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","Request":{"name":"test-name","capacity_range":{"required_bytes":21474836480},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}],"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"info","ts":"2021-07-29T02:04:03.220-0700","caller":"ibmcsidriver/controller_helper.go:214","msg":"Volume size in bytes","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","capacity":21474836480}
{"level":"info","ts":"2021-07-29T02:04:03.220-0700","caller":"ibmcsidriver/controller_helper.go:220","msg":"Volume size in GiB","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","capacity":20}
{"level":"info","ts":"2021-07-29T02:04:03.220-0700","caller":"ibmcsidriver/controller.go:95","msg":"Volume request after masking encryption key","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","Volume":{"provider":"","volumeType":"ext2","capacity":20,"iops":null,"tier":null,"region":"myregion","az":"myzone","creationTime":"0001-01-01T00:00:00Z","name":"test-name","resource_group":{},"encryption_key":{"crn":"********"},"profile":{"name":"general-purpose"}}}
{"level":"error","ts":"2021-07-29T02:04:03.220-0700","caller":"ibmcsidriver/controller_helper.go:404","msg":"checkIfVolumeExists","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","Error":"{Code:FailedToPlaceOrder, Type:InvalidRequest, Description:Volume creation failed, BackendError:, RC:0}"}
{"level":"error","ts":"2021-07-29T02:04:03.221-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","error":"{RequestID: da1e7821-2a28-4c6c-a250-ff1fafd4a565 , Code: InternalError, Description: Internal error occurred%!(EXTRA string=creation), BackendError: {Code:FailedToPlaceOrder, Type:InvalidRequest, Description:Volume creation failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.221-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"da1e7821-2a28-4c6c-a250-ff1fafd4a565","CreateVolume":0.000468758}
    controller_test.go:207: test case: Other error lib error form create volume
{"level":"info","ts":"2021-07-29T02:04:03.222-0700","caller":"ibmcsidriver/controller.go:67","msg":"CSIControllerServer-CreateVolume... ","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","Request":{"name":"test-name","capacity_range":{"required_bytes":21474836480},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}],"parameters":{"profile":"general-purpose","region":"myregion","zone":"myzone"}}}
{"level":"info","ts":"2021-07-29T02:04:03.222-0700","caller":"ibmcsidriver/controller_helper.go:214","msg":"Volume size in bytes","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","capacity":21474836480}
{"level":"info","ts":"2021-07-29T02:04:03.222-0700","caller":"ibmcsidriver/controller_helper.go:220","msg":"Volume size in GiB","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","capacity":20}
{"level":"info","ts":"2021-07-29T02:04:03.222-0700","caller":"ibmcsidriver/controller.go:95","msg":"Volume request after masking encryption key","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","Volume":{"provider":"","volumeType":"ext2","capacity":20,"iops":null,"tier":null,"region":"myregion","az":"myzone","creationTime":"0001-01-01T00:00:00Z","name":"test-name","resource_group":{},"encryption_key":{"crn":"********"},"profile":{"name":"general-purpose"}}}
{"level":"error","ts":"2021-07-29T02:04:03.222-0700","caller":"ibmcsidriver/controller_helper.go:404","msg":"checkIfVolumeExists","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","Error":"{Code:FailedToPlaceOrder, Type:Unauthenticated, Description:Volume creation failed, BackendError:, RC:0}"}
{"level":"error","ts":"2021-07-29T02:04:03.222-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","error":"{RequestID: 8cda72ed-6a67-46e0-95f7-f1dd9e012464 , Code: InternalError, Description: Internal error occurred%!(EXTRA string=creation), BackendError: {Code:FailedToPlaceOrder, Type:Unauthenticated, Description:Volume creation failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.222-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"8cda72ed-6a67-46e0-95f7-f1dd9e012464","CreateVolume":0.000580928}
--- PASS: TestCreateVolumeArguments (0.01s)
=== RUN   TestDeleteVolume
    controller_test.go:300: test case: Success volume delete
{"level":"info","ts":"2021-07-29T02:04:03.224-0700","caller":"ibmcsidriver/controller.go:136","msg":"CSIControllerServer-DeleteVolume... ","RequestID":"22d6a86d-d544-4e56-9cca-c5e7d0bdcff0","Request":{"volume_id":"testVolumeId"}}
{"level":"info","ts":"2021-07-29T02:04:03.224-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"22d6a86d-d544-4e56-9cca-c5e7d0bdcff0","DeleteVolume":0.000211014}
    controller_test.go:300: test case: Success volume delete in case volume not found
{"level":"info","ts":"2021-07-29T02:04:03.225-0700","caller":"ibmcsidriver/controller.go:136","msg":"CSIControllerServer-DeleteVolume... ","RequestID":"f7f989a7-1176-4730-ab98-2b25f2f6d811","Request":{"volume_id":"testVolumeId"}}
{"level":"info","ts":"2021-07-29T02:04:03.225-0700","caller":"ibmcsidriver/controller.go:158","msg":"Volume not found. Returning success without deletion...","RequestID":"f7f989a7-1176-4730-ab98-2b25f2f6d811"}
{"level":"info","ts":"2021-07-29T02:04:03.226-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"f7f989a7-1176-4730-ab98-2b25f2f6d811","DeleteVolume":0.000133998}
    controller_test.go:300: test case: Failed volume delete with volume id empty
{"level":"info","ts":"2021-07-29T02:04:03.227-0700","caller":"ibmcsidriver/controller.go:136","msg":"CSIControllerServer-DeleteVolume... ","RequestID":"5d8f62e0-beda-4dac-8ead-ce3bf19561b6","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.227-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"5d8f62e0-beda-4dac-8ead-ce3bf19561b6","error":"{RequestID: 5d8f62e0-beda-4dac-8ead-ce3bf19561b6 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
{"level":"info","ts":"2021-07-29T02:04:03.227-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"5d8f62e0-beda-4dac-8ead-ce3bf19561b6","DeleteVolume":0.000186706}
    controller_test.go:300: test case: Failed from lib volume delete failed
{"level":"info","ts":"2021-07-29T02:04:03.228-0700","caller":"ibmcsidriver/controller.go:136","msg":"CSIControllerServer-DeleteVolume... ","RequestID":"ee98d71f-c9dd-4301-ab98-75d40f0f4a1d","Request":{"volume_id":"testVolumeId"}}
{"level":"error","ts":"2021-07-29T02:04:03.228-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"ee98d71f-c9dd-4301-ab98-75d40f0f4a1d","error":"{RequestID: ee98d71f-c9dd-4301-ab98-75d40f0f4a1d , Code: InternalError, Description: Internal error occurred, BackendError: {Code:FailedToDeleteVolume, Type:DeletionFailed, Description:Volume deletion failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.228-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"ee98d71f-c9dd-4301-ab98-75d40f0f4a1d","DeleteVolume":0.000220885}
--- PASS: TestDeleteVolume (0.01s)
=== RUN   TestControllerPublishVolume
    controller_test.go:439: test case: Success attachment
{"level":"info","ts":"2021-07-29T02:04:03.229-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"46816cb1-1695-4a65-a485-e37f05668554","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:04:03.230-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"46816cb1-1695-4a65-a485-e37f05668554","ControllerPublishVolume.Lock":0.000005674}
{"level":"info","ts":"2021-07-29T02:04:03.230-0700","caller":"ibmcsidriver/controller.go:247","msg":"Attachment response","RequestID":"46816cb1-1695-4a65-a485-e37f05668554","Response":{"volumeID":"vol123","instanceID":"node123","vpcVolumeAttachment":{"device_path":"/tmp"},"iksVolumeAttachment":null}}
{"level":"info","ts":"2021-07-29T02:04:03.230-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"46816cb1-1695-4a65-a485-e37f05668554","ControllerPublishVolume":0.000588189}
    controller_test.go:439: test case: Failed AttachVolume library call for node not found
{"level":"info","ts":"2021-07-29T02:04:03.231-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"3859732f-30a9-40f7-8735-8f065d955220","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:04:03.231-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"3859732f-30a9-40f7-8735-8f065d955220","ControllerPublishVolume.Lock":0.000007753}
{"level":"error","ts":"2021-07-29T02:04:03.231-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"3859732f-30a9-40f7-8735-8f065d955220","error":"{RequestID: 3859732f-30a9-40f7-8735-8f065d955220 , Code: ObjectNotFound, Description: Object not found, BackendError: {Code:AttachFailed, Type:NodeNotFound, Description:Volume attach failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.232-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"3859732f-30a9-40f7-8735-8f065d955220","ControllerPublishVolume":0.000231585}
    controller_test.go:439: test case: Failed AttachVolume library call AttachVolume failed with internal error
{"level":"info","ts":"2021-07-29T02:04:03.233-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"a14a3572-47a3-4f68-a51c-eb0c110017db","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:04:03.233-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"a14a3572-47a3-4f68-a51c-eb0c110017db","ControllerPublishVolume.Lock":0.000003613}
{"level":"error","ts":"2021-07-29T02:04:03.233-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"a14a3572-47a3-4f68-a51c-eb0c110017db","error":"{RequestID: a14a3572-47a3-4f68-a51c-eb0c110017db , Code: InternalError, Description: Internal error occurred, BackendError: {Code:AttachFailed, Type:PermissionDenied, Description:Volume attach failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.233-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"a14a3572-47a3-4f68-a51c-eb0c110017db","ControllerPublishVolume":0.000209696}
    controller_test.go:439: test case: Failed AttachVolume library call for volume not found
{"level":"info","ts":"2021-07-29T02:04:03.234-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"3ba75ae1-5481-4ad4-ad83-e825db72eaa8","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:04:03.234-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"3ba75ae1-5481-4ad4-ad83-e825db72eaa8","ControllerPublishVolume.Lock":0.00000362}
{"level":"error","ts":"2021-07-29T02:04:03.234-0700","caller":"ibmcsidriver/controller_helper.go:404","msg":"checkIfVolumeExists","RequestID":"3ba75ae1-5481-4ad4-ad83-e825db72eaa8","Error":"{Code:EntityNotFound, Type:EntityNotFound, Description:Volume not found, BackendError:, RC:0}"}
{"level":"error","ts":"2021-07-29T02:04:03.234-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"3ba75ae1-5481-4ad4-ad83-e825db72eaa8","error":"{RequestID: 3ba75ae1-5481-4ad4-ad83-e825db72eaa8 , Code: ObjectNotFound, Description: Object not found%!(EXTRA string=vol123), Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.234-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"3ba75ae1-5481-4ad4-ad83-e825db72eaa8","ControllerPublishVolume":0.000422808}
    controller_test.go:439: test case: Failed AttachVolume library call internal error for get volume call
{"level":"info","ts":"2021-07-29T02:04:03.235-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"72c2303a-2894-4c7d-9780-e798ca56e569","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:04:03.235-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"72c2303a-2894-4c7d-9780-e798ca56e569","ControllerPublishVolume.Lock":0.00001715}
{"level":"error","ts":"2021-07-29T02:04:03.235-0700","caller":"ibmcsidriver/controller_helper.go:404","msg":"checkIfVolumeExists","RequestID":"72c2303a-2894-4c7d-9780-e798ca56e569","Error":"{Code:, Type:PermissionDenied, Description:internal error, BackendError:, RC:0}"}
{"level":"error","ts":"2021-07-29T02:04:03.235-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"72c2303a-2894-4c7d-9780-e798ca56e569","error":"{RequestID: 72c2303a-2894-4c7d-9780-e798ca56e569 , Code: InternalError, Description: Internal error occurred, BackendError: {Code:, Type:PermissionDenied, Description:internal error, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.236-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"72c2303a-2894-4c7d-9780-e798ca56e569","ControllerPublishVolume":0.000325374}
    controller_test.go:439: test case: Failed volume id empty
{"level":"info","ts":"2021-07-29T02:04:03.237-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"18d113c5-f62b-4570-b9cb-6c252f4d2897","Request":{"node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"error","ts":"2021-07-29T02:04:03.237-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"18d113c5-f62b-4570-b9cb-6c252f4d2897","error":"{RequestID: 18d113c5-f62b-4570-b9cb-6c252f4d2897 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
{"level":"info","ts":"2021-07-29T02:04:03.237-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"18d113c5-f62b-4570-b9cb-6c252f4d2897","ControllerPublishVolume":0.000084659}
    controller_test.go:439: test case: Failed node id empty
{"level":"info","ts":"2021-07-29T02:04:03.238-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"307626fa-1e6d-4d39-a7be-a50ba720b54f","Request":{"volume_id":"vol123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"error","ts":"2021-07-29T02:04:03.238-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"307626fa-1e6d-4d39-a7be-a50ba720b54f","error":"{RequestID: 307626fa-1e6d-4d39-a7be-a50ba720b54f , Code: EmptyNodeID, Description: NodeID is empty, Action: Please check all node's labels by using kubectl command}"}
{"level":"info","ts":"2021-07-29T02:04:03.238-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"307626fa-1e6d-4d39-a7be-a50ba720b54f","ControllerPublishVolume":0.000209581}
    controller_test.go:439: test case: Failed nil volume capabilities
{"level":"info","ts":"2021-07-29T02:04:03.240-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"a07a80c0-44e1-44a6-b19f-54c50a5ae372","Request":{"volume_id":"vol123","node_id":"node123"}}
{"level":"error","ts":"2021-07-29T02:04:03.240-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"a07a80c0-44e1-44a6-b19f-54c50a5ae372","error":"{RequestID: a07a80c0-44e1-44a6-b19f-54c50a5ae372 , Code: NoVolumeCapabilities, Description: Volume capabilities must be provided, Action: Please provide volume capabilities in the storage class before creating volume}"}
{"level":"info","ts":"2021-07-29T02:04:03.240-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"a07a80c0-44e1-44a6-b19f-54c50a5ae372","ControllerPublishVolume":0.000159212}
    controller_test.go:439: test case: Failed unsupported volume capability
{"level":"info","ts":"2021-07-29T02:04:03.241-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"5a735212-b8de-45db-9fe7-aa06a2facf6a","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":5}}}}
{"level":"info","ts":"2021-07-29T02:04:03.241-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"5a735212-b8de-45db-9fe7-aa06a2facf6a","ControllerPublishVolume.Lock":0.000010994}
{"level":"error","ts":"2021-07-29T02:04:03.241-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"5a735212-b8de-45db-9fe7-aa06a2facf6a","error":"{RequestID: 5a735212-b8de-45db-9fe7-aa06a2facf6a , Code: VolumeCapabilitiesNotSupported, Description: Volume capabilities not supported, Action: Please provide valid volume capabilities while creating volume}"}
{"level":"info","ts":"2021-07-29T02:04:03.241-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"5a735212-b8de-45db-9fe7-aa06a2facf6a","ControllerPublishVolume":0.000215984}
    controller_test.go:439: test case: Failed while waiting for attachment
{"level":"info","ts":"2021-07-29T02:04:03.242-0700","caller":"ibmcsidriver/controller.go:174","msg":"CSIControllerServer-ControllerPublishVolume...","RequestID":"91369041-38f0-4200-885a-98e0f0805e66","Request":{"volume_id":"vol123","node_id":"node123","volume_capability":{"AccessType":null,"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:04:03.243-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"91369041-38f0-4200-885a-98e0f0805e66","ControllerPublishVolume.Lock":0.000004874}
{"level":"error","ts":"2021-07-29T02:04:03.243-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"91369041-38f0-4200-885a-98e0f0805e66","error":"{RequestID: 91369041-38f0-4200-885a-98e0f0805e66 , Code: InternalError, Description: Internal error occurred, BackendError: {Code:, Type:, Description:internal error while waiting for attachment, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.243-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"91369041-38f0-4200-885a-98e0f0805e66","ControllerPublishVolume":0.000258805}
--- PASS: TestControllerPublishVolume (0.01s)
=== RUN   TestControllerUnpublishVolume
    controller_test.go:534: test case: Success detach volume
{"level":"info","ts":"2021-07-29T02:04:03.244-0700","caller":"ibmcsidriver/controller.go:258","msg":"CSIControllerServer-ControllerUnpublishVolume... ","RequestID":"eb218a5f-f3b8-4893-a3fa-86cdea0ff5b6","Request":{"volume_id":"volumeid","node_id":"nodeid"}}
{"level":"info","ts":"2021-07-29T02:04:03.245-0700","caller":"ibmcsidriver/controller.go:294","msg":"Detach response","RequestID":"eb218a5f-f3b8-4893-a3fa-86cdea0ff5b6","response":{"Status":"","StatusCode":200,"Proto":"","ProtoMajor":0,"ProtoMinor":0,"Header":null,"Body":null,"ContentLength":0,"TransferEncoding":null,"Close":false,"Uncompressed":false,"Trailer":null,"Request":null,"TLS":null}}
{"level":"info","ts":"2021-07-29T02:04:03.248-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"eb218a5f-f3b8-4893-a3fa-86cdea0ff5b6","ControllerUnpublishVolume":0.003172684}
    controller_test.go:534: test case: Nil volume ID
{"level":"info","ts":"2021-07-29T02:04:03.249-0700","caller":"ibmcsidriver/controller.go:258","msg":"CSIControllerServer-ControllerUnpublishVolume... ","RequestID":"65123e33-862c-4383-821d-4df210e41c57","Request":{"node_id":"nodeid"}}
{"level":"error","ts":"2021-07-29T02:04:03.249-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"65123e33-862c-4383-821d-4df210e41c57","error":"{RequestID: 65123e33-862c-4383-821d-4df210e41c57 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
{"level":"info","ts":"2021-07-29T02:04:03.249-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"65123e33-862c-4383-821d-4df210e41c57","ControllerUnpublishVolume":0.000227968}
    controller_test.go:534: test case: Nil node ID
{"level":"info","ts":"2021-07-29T02:04:03.250-0700","caller":"ibmcsidriver/controller.go:258","msg":"CSIControllerServer-ControllerUnpublishVolume... ","RequestID":"4cd4375d-b5ee-4750-b686-f92c64f7ced4","Request":{"volume_id":"volumeid"}}
{"level":"error","ts":"2021-07-29T02:04:03.250-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"4cd4375d-b5ee-4750-b686-f92c64f7ced4","error":"{RequestID: 4cd4375d-b5ee-4750-b686-f92c64f7ced4 , Code: EmptyNodeID, Description: NodeID is empty, Action: Please check all node's labels by using kubectl command}"}
{"level":"info","ts":"2021-07-29T02:04:03.250-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"4cd4375d-b5ee-4750-b686-f92c64f7ced4","ControllerUnpublishVolume":0.000209629}
    controller_test.go:534: test case: Detach volume failed
{"level":"info","ts":"2021-07-29T02:04:03.251-0700","caller":"ibmcsidriver/controller.go:258","msg":"CSIControllerServer-ControllerUnpublishVolume... ","RequestID":"29e81080-35e8-4ba8-bde4-a34abbf91652","Request":{"volume_id":"volumeid","node_id":"nodeid"}}
{"level":"error","ts":"2021-07-29T02:04:03.251-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"29e81080-35e8-4ba8-bde4-a34abbf91652","error":"{RequestID: 29e81080-35e8-4ba8-bde4-a34abbf91652 , Code: InternalError, Description: Internal error occurred, BackendError: {Code:, Type:DetachFailed, Description:Volume detach failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.252-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"29e81080-35e8-4ba8-bde4-a34abbf91652","ControllerUnpublishVolume":0.000309979}
    controller_test.go:534: test case: Wait for detach volume failed
{"level":"info","ts":"2021-07-29T02:04:03.253-0700","caller":"ibmcsidriver/controller.go:258","msg":"CSIControllerServer-ControllerUnpublishVolume... ","RequestID":"7cbb9f7f-4670-4177-b090-9e1ea0344865","Request":{"volume_id":"volumeid","node_id":"nodeid"}}
{"level":"error","ts":"2021-07-29T02:04:03.253-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"7cbb9f7f-4670-4177-b090-9e1ea0344865","error":"{RequestID: 7cbb9f7f-4670-4177-b090-9e1ea0344865 , Code: InternalError, Description: Internal error occurred, BackendError: {Code:, Type:RetrivalFailed, Description:Volume detach status failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.253-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"7cbb9f7f-4670-4177-b090-9e1ea0344865","ControllerUnpublishVolume":0.000307408}
--- PASS: TestControllerUnpublishVolume (0.01s)
=== RUN   TestValidateVolumeCapabilities
    controller_test.go:631: test case: Success validate volume capabilities
{"level":"info","ts":"2021-07-29T02:04:03.254-0700","caller":"ibmcsidriver/controller.go:303","msg":"CSIControllerServer-ValidateVolumeCapabilities","RequestID":"bbd158da-85ee-4120-b45b-6c148c39e252","Request":{"volume_id":"volumeid","volume_capabilities":[{"AccessType":null,"access_mode":{"mode":1}}]}}
    controller_test.go:631: test case: Passing nil volume capabilities
{"level":"info","ts":"2021-07-29T02:04:03.256-0700","caller":"ibmcsidriver/controller.go:303","msg":"CSIControllerServer-ValidateVolumeCapabilities","RequestID":"03236cf0-5bdd-48f6-87f9-c4cba7561ffa","Request":{"volume_id":"volumeid"}}
{"level":"error","ts":"2021-07-29T02:04:03.256-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"03236cf0-5bdd-48f6-87f9-c4cba7561ffa","error":"{RequestID: 03236cf0-5bdd-48f6-87f9-c4cba7561ffa , Code: NoVolumeCapabilities, Description: Volume capabilities must be provided, Action: Please provide volume capabilities in the storage class before creating volume}"}
    controller_test.go:645: Error code
    controller_test.go:631: test case: Passing nil volume ID
{"level":"info","ts":"2021-07-29T02:04:03.257-0700","caller":"ibmcsidriver/controller.go:303","msg":"CSIControllerServer-ValidateVolumeCapabilities","RequestID":"7e87debc-b612-4361-8dd0-cb645ebf47c9","Request":{"volume_capabilities":[{"AccessType":null,"access_mode":{"mode":1}}]}}
{"level":"error","ts":"2021-07-29T02:04:03.257-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"7e87debc-b612-4361-8dd0-cb645ebf47c9","error":"{RequestID: 7e87debc-b612-4361-8dd0-cb645ebf47c9 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    controller_test.go:645: Error code
    controller_test.go:631: test case: Get volume failed
{"level":"info","ts":"2021-07-29T02:04:03.258-0700","caller":"ibmcsidriver/controller.go:303","msg":"CSIControllerServer-ValidateVolumeCapabilities","RequestID":"b4df78ac-c355-4d29-babd-0ef53e696f7a","Request":{"volume_id":"volume-not-found-ID","volume_capabilities":[{"AccessType":null,"access_mode":{"mode":1}}]}}
{"level":"error","ts":"2021-07-29T02:04:03.259-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"b4df78ac-c355-4d29-babd-0ef53e696f7a","error":"{RequestID: b4df78ac-c355-4d29-babd-0ef53e696f7a , Code: ObjectNotFound, Description: Object not found%!(EXTRA string=volume-not-found-ID), BackendError: {Code:StorageFindFailedWithVolumeName, Type:RetrivalFailed, Description:Volume not found by volume ID, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
    controller_test.go:645: Error code
    controller_test.go:631: test case: Internal error while getting volume details
{"level":"info","ts":"2021-07-29T02:04:03.260-0700","caller":"ibmcsidriver/controller.go:303","msg":"CSIControllerServer-ValidateVolumeCapabilities","RequestID":"bbca0a4e-bda7-4622-9d82-40d18913fb16","Request":{"volume_id":"volumeid","volume_capabilities":[{"AccessType":null,"access_mode":{"mode":1}}]}}
{"level":"error","ts":"2021-07-29T02:04:03.260-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"bbca0a4e-bda7-4622-9d82-40d18913fb16","error":"{RequestID: bbca0a4e-bda7-4622-9d82-40d18913fb16 , Code: InternalError, Description: Internal error occurred, BackendError: {Code:StorageFindFailed, Type:PermissionDenied, Description:Internal error, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
    controller_test.go:645: Error code
--- PASS: TestValidateVolumeCapabilities (0.01s)
=== RUN   TestListVolumes
    controller_test.go:715: test case: normal
{"level":"info","ts":"2021-07-29T02:04:03.262-0700","caller":"ibmcsidriver/controller.go:347","msg":"CSIControllerServer-ListVolumes...","RequestID":"6a18ec6f-d37f-4c32-bc90-aaf9ec82ed38","Request":{}}
{"level":"info","ts":"2021-07-29T02:04:03.262-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"6a18ec6f-d37f-4c32-bc90-aaf9ec82ed38","ListVolumes":0.000069378}
    controller_test.go:715: test case: fine amount of entries
{"level":"info","ts":"2021-07-29T02:04:03.264-0700","caller":"ibmcsidriver/controller.go:347","msg":"CSIControllerServer-ListVolumes...","RequestID":"59eebe96-5445-4524-9b7e-34481cd92c96","Request":{"max_entries":40}}
{"level":"info","ts":"2021-07-29T02:04:03.264-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"59eebe96-5445-4524-9b7e-34481cd92c96","ListVolumes":0.000041475}
    controller_test.go:715: test case: too many entries, but defaults to 100
{"level":"info","ts":"2021-07-29T02:04:03.266-0700","caller":"ibmcsidriver/controller.go:347","msg":"CSIControllerServer-ListVolumes...","RequestID":"704d3bd7-a81e-493f-8e91-17bd9de65bbb","Request":{"max_entries":101}}
{"level":"info","ts":"2021-07-29T02:04:03.266-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"704d3bd7-a81e-493f-8e91-17bd9de65bbb","ListVolumes":0.000175775}
    controller_test.go:715: test case: negative entries
{"level":"info","ts":"2021-07-29T02:04:03.267-0700","caller":"ibmcsidriver/controller.go:347","msg":"CSIControllerServer-ListVolumes...","RequestID":"ece4a68b-d7a1-4d27-91c9-0a9545b15711","Request":{"max_entries":-1}}
{"level":"error","ts":"2021-07-29T02:04:03.268-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"ece4a68b-d7a1-4d27-91c9-0a9545b15711","error":"{RequestID: ece4a68b-d7a1-4d27-91c9-0a9545b15711 , Code: InvalidParameters, Description: Failed to extract parameters, BackendError: {Code:InvalidListVolumesLimit, Type:InvalidRequest, Description:The value '-1' specified in the limit parameter of the list volume call is not valid., BackendError:, RC:0}, Action: Please provide valid parameters}"}
{"level":"info","ts":"2021-07-29T02:04:03.268-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"ece4a68b-d7a1-4d27-91c9-0a9545b15711","ListVolumes":0.000181656}
    controller_test.go:715: test case: Invalid start volume ID
{"level":"info","ts":"2021-07-29T02:04:03.269-0700","caller":"ibmcsidriver/controller.go:347","msg":"CSIControllerServer-ListVolumes...","RequestID":"63d6bbc8-6fd1-43e6-84cf-cc073250bde1","Request":{"max_entries":10}}
{"level":"error","ts":"2021-07-29T02:04:03.272-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"63d6bbc8-6fd1-43e6-84cf-cc073250bde1","error":"{RequestID: 63d6bbc8-6fd1-43e6-84cf-cc073250bde1 , Code: StartVolumeIDNotFound, Description: The volume ID '' specified in the start parameter of the list volume call could not be found, BackendError: {Code:StartVolumeIDNotFound, Type:InvalidRequest, Description:The volume ID specified in the start parameter of the list volume call could not be found., BackendError:, RC:0}, Action: Please verify that the start volume ID is correct and whether you have access to the volume ID}"}
{"level":"info","ts":"2021-07-29T02:04:03.272-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"63d6bbc8-6fd1-43e6-84cf-cc073250bde1","ListVolumes":0.000715561}
    controller_test.go:715: test case: internal error
{"level":"info","ts":"2021-07-29T02:04:03.275-0700","caller":"ibmcsidriver/controller.go:347","msg":"CSIControllerServer-ListVolumes...","RequestID":"5003ac4c-05dc-48be-b5cc-0351b26519c3","Request":{"max_entries":10}}
{"level":"error","ts":"2021-07-29T02:04:03.276-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"5003ac4c-05dc-48be-b5cc-0351b26519c3","error":"{RequestID: 5003ac4c-05dc-48be-b5cc-0351b26519c3 , Code: ListVolumesFailed, Description: Failed to list volumes, BackendError: {Code:ListVolumesFailed, Type:RetrivalFailed, Description:Unable to fetch list of volumes., BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
{"level":"info","ts":"2021-07-29T02:04:03.276-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"5003ac4c-05dc-48be-b5cc-0351b26519c3","ListVolumes":0.000384207}
--- PASS: TestListVolumes (0.02s)
=== RUN   TestGetCapacity
    controller_test.go:785: test case: Success get capacity
{"level":"info","ts":"2021-07-29T02:04:03.279-0700","caller":"ibmcsidriver/controller.go:392","msg":"CSIControllerServer-GetCapacity","RequestID":"9c2180d2-44f6-4ba5-82ca-085c57b6dede","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.279-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"9c2180d2-44f6-4ba5-82ca-085c57b6dede","error":"{RequestID: 9c2180d2-44f6-4ba5-82ca-085c57b6dede , Code: MethodUnimplemented, Description: 'GetCapacity' CSI interface method not yet implemented, Action: Please do not use this method as its not implemented yet}"}
--- PASS: TestGetCapacity (0.00s)
=== RUN   TestControllerGetCapabilities
    controller_test.go:837: test case: Success controller get capabilities
{"level":"info","ts":"2021-07-29T02:04:03.282-0700","caller":"ibmcsidriver/controller.go:402","msg":"CSIControllerServer-GetCapacity","RequestID":"376483f2-b9c6-44a9-af79-6a8698523cdf","Request":{}}
--- PASS: TestControllerGetCapabilities (0.00s)
=== RUN   TestCreateSnapshot
    controller_test.go:881: test case: Success create snapshot
{"level":"info","ts":"2021-07-29T02:04:03.285-0700","caller":"ibmcsidriver/controller.go:415","msg":"CSIControllerServer-CreateSnapshot","RequestID":"e0fb2975-cc2d-4a50-bafe-7e63ae1e4fb0","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.286-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"e0fb2975-cc2d-4a50-bafe-7e63ae1e4fb0","error":"{RequestID: e0fb2975-cc2d-4a50-bafe-7e63ae1e4fb0 , Code: MethodUnimplemented, Description: 'CreateSnapshot' CSI interface method not yet implemented, Action: Please do not use this method as its not implemented yet}"}
--- PASS: TestCreateSnapshot (0.00s)
=== RUN   TestDeleteSnapshot
    controller_test.go:922: test case: Success delete snapshot
{"level":"info","ts":"2021-07-29T02:04:03.288-0700","caller":"ibmcsidriver/controller.go:425","msg":"CSIControllerServer-DeleteSnapshot","RequestID":"45c746ab-9374-440f-b399-6c92899edce6","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.288-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"45c746ab-9374-440f-b399-6c92899edce6","error":"{RequestID: 45c746ab-9374-440f-b399-6c92899edce6 , Code: MethodUnimplemented, Description: 'DeleteSnapshot' CSI interface method not yet implemented, Action: Please do not use this method as its not implemented yet}"}
--- PASS: TestDeleteSnapshot (0.00s)
=== RUN   TestListSnapshots
    controller_test.go:963: test case: Success list snapshots
{"level":"info","ts":"2021-07-29T02:04:03.290-0700","caller":"ibmcsidriver/controller.go:435","msg":"CSIControllerServer-ListSnapshots","RequestID":"ce5b1577-64bd-4235-9716-3a24547d4610","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.291-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"ce5b1577-64bd-4235-9716-3a24547d4610","error":"{RequestID: ce5b1577-64bd-4235-9716-3a24547d4610 , Code: MethodUnimplemented, Description: 'ListSnapshots' CSI interface method not yet implemented, Action: Please do not use this method as its not implemented yet}"}
--- PASS: TestListSnapshots (0.00s)
=== RUN   TestGetSnapshots
    controller_test.go:1004: test case: Success get snapshots
{"level":"info","ts":"2021-07-29T02:04:03.293-0700","caller":"ibmcsidriver/controller.go:445","msg":"CSIControllerServer-getSnapshots","RequestID":"830bc79f-8ba6-4dfc-ae11-cf81aab588ff","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.293-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"830bc79f-8ba6-4dfc-ae11-cf81aab588ff","error":"{RequestID: 830bc79f-8ba6-4dfc-ae11-cf81aab588ff , Code: MethodUnimplemented, Description: 'getSnapshots' CSI interface method not yet implemented, Action: Please do not use this method as its not implemented yet}"}
--- PASS: TestGetSnapshots (0.00s)
=== RUN   TestGetSnapshotByID
    controller_test.go:1045: test case: Success get snapshotByID
{"level":"info","ts":"2021-07-29T02:04:03.295-0700","caller":"ibmcsidriver/controller.go:455","msg":"CSIControllerServer-getSnapshotByID","RequestID":"b8e67ac3-96ef-4118-a639-20c182bb8dd6","Request":"snapshotID"}
{"level":"error","ts":"2021-07-29T02:04:03.295-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"b8e67ac3-96ef-4118-a639-20c182bb8dd6","error":"{RequestID: b8e67ac3-96ef-4118-a639-20c182bb8dd6 , Code: MethodUnimplemented, Description: 'getSnapshotByID' CSI interface method not yet implemented, Action: Please do not use this method as its not implemented yet}"}
--- PASS: TestGetSnapshotByID (0.00s)
=== RUN   TestControllerExpandVolume
    controller_test.go:1129: test case: Success controller expand volume
{"level":"info","ts":"2021-07-29T02:04:03.297-0700","caller":"ibmcsidriver/controller.go:465","msg":"CSIControllerServer-ControllerExpandVolume","RequestID":"75041c86-39ce-4c52-9778-1661fbc6f600","Request":{"volume_id":"volumeid","capacity_range":{"required_bytes":21474836480}}}
    controller_test.go:1129: test case: Nil capacity
{"level":"info","ts":"2021-07-29T02:04:03.299-0700","caller":"ibmcsidriver/controller.go:465","msg":"CSIControllerServer-ControllerExpandVolume","RequestID":"083f853e-1d3a-430a-a8ab-47d812e3a12c","Request":{"volume_id":"volumeid"}}
{"level":"error","ts":"2021-07-29T02:04:03.299-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"083f853e-1d3a-430a-a8ab-47d812e3a12c","error":"{RequestID: 083f853e-1d3a-430a-a8ab-47d812e3a12c , Code: ObjectNotFound, Description: Object not found%!(EXTRA string=volumeid), Action: Please check 'BackendError' tag for more details}"}
    controller_test.go:1147: Error code
    controller_test.go:1129: test case: Nil volume ID
{"level":"info","ts":"2021-07-29T02:04:03.300-0700","caller":"ibmcsidriver/controller.go:465","msg":"CSIControllerServer-ControllerExpandVolume","RequestID":"a39f3500-d10d-484a-9552-cb9c146b0b92","Request":{"capacity_range":{"required_bytes":21474836480}}}
{"level":"error","ts":"2021-07-29T02:04:03.301-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"a39f3500-d10d-484a-9552-cb9c146b0b92","error":"{RequestID: a39f3500-d10d-484a-9552-cb9c146b0b92 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    controller_test.go:1147: Error code
    controller_test.go:1129: test case: Expand volume failed
{"level":"info","ts":"2021-07-29T02:04:03.302-0700","caller":"ibmcsidriver/controller.go:465","msg":"CSIControllerServer-ControllerExpandVolume","RequestID":"4b06367d-1236-47d7-bd53-137c80087a2c","Request":{"volume_id":"volumeid","capacity_range":{"required_bytes":21474836480}}}
{"level":"error","ts":"2021-07-29T02:04:03.302-0700","caller":"ibmcsidriver/controller_helper.go:404","msg":"checkIfVolumeExists","RequestID":"4b06367d-1236-47d7-bd53-137c80087a2c","Error":"{Code:FailedToPlaceOrder, Type:Unauthenticated, Description:Volume expansion failed, BackendError:, RC:0}"}
{"level":"error","ts":"2021-07-29T02:04:03.302-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"4b06367d-1236-47d7-bd53-137c80087a2c","error":"{RequestID: 4b06367d-1236-47d7-bd53-137c80087a2c , Code: InternalError, Description: Internal error occurred, BackendError: {Code:FailedToPlaceOrder, Type:Unauthenticated, Description:Volume expansion failed, BackendError:, RC:0}, Action: Please check 'BackendError' tag for more details}"}
    controller_test.go:1147: Error code
--- PASS: TestControllerExpandVolume (0.01s)
=== RUN   TestSetupIBMCSIDriver
--- PASS: TestSetupIBMCSIDriver (0.00s)
=== RUN   TestGetPluginInfo
{"level":"info","ts":"2021-07-29T02:04:03.306-0700","caller":"ibmcsidriver/identity.go:36","msg":"CSIIdentityServer-GetPluginInfo...","RequestID":"acd527ad-e06f-4ed9-a8ef-6f44af560a73","Request":{}}
{"level":"info","ts":"2021-07-29T02:04:03.306-0700","caller":"ibmcsidriver/identity.go:36","msg":"CSIIdentityServer-GetPluginInfo...","RequestID":"a16b7226-a202-47e3-bc7c-ed70d10fd711","Request":{}}
{"level":"error","ts":"2021-07-29T02:04:03.306-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"a16b7226-a202-47e3-bc7c-ed70d10fd711","error":"{RequestID: a16b7226-a202-47e3-bc7c-ed70d10fd711 , Code: DriverNotConfigured, Description: Driver name not configured, Action: Developer need to set the driver name}"}
--- PASS: TestGetPluginInfo (0.00s)
=== RUN   TestGetPluginCapabilities
{"level":"info","ts":"2021-07-29T02:04:03.308-0700","caller":"ibmcsidriver/identity.go:51","msg":"CSIIdentityServer-GetPluginCapabilities...","RequestID":"cc94dc6d-0ccd-41fc-b9dd-3bd4f56765e9","Request":{}}
--- PASS: TestGetPluginCapabilities (0.00s)
=== RUN   TestProbe
{"level":"info","ts":"2021-07-29T02:04:03.310-0700","caller":"ibmcsidriver/identity.go:83","msg":"CSIIdentityServer-Probe...","RequestID":"b5efe4ca-2983-436c-bebf-cc99af73df2d","Request":{}}
--- PASS: TestProbe (0.00s)
=== RUN   TestFindDevicePathSource
    node_helper_test.go:53: Test case: Valid device path
    node_helper_test.go:53: Test case: nvme device path
--- PASS: TestFindDevicePathSource (40.15s)
=== RUN   TestProcessMount
    node_helper_test.go:70: Response , error <nil>
--- PASS: TestProcessMount (0.01s)
=== RUN   TestUdevadmTrigger
    node_helper_test.go:80: Response error <nil>
--- PASS: TestUdevadmTrigger (20.08s)
=== RUN   TestProcessMountForBlock
    node_helper_test.go:91: Response , error <nil>
--- PASS: TestProcessMountForBlock (20.07s)
=== RUN   TestNodePublishVolume
    node_test.go:200: Test case: Valid request
{"level":"info","ts":"2021-07-29T02:05:23.619-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"csiprovidervolumeid","staging_target_path":"/staging","target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:23.620-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000001765}
{"level":"info","ts":"2021-07-29T02:05:23.620-0700","caller":"ibmcsidriver/node_helper.go:62","msg":"CSINodeServer-processMount...","RequestID":"","stagingTargetPath":"/staging","targetPath":"/mnt/test","fsType":"","options":["bind"]}
{"level":"info","ts":"2021-07-29T02:05:23.620-0700","caller":"ibmcsidriver/node_helper.go:89","msg":"CSINodeServer-processMount successfully mounted","RequestID":"","stagingTargetPath":"/staging","targetPath":"/mnt/test","fsType":"","options":["bind"]}
{"level":"info","ts":"2021-07-29T02:05:23.620-0700","caller":"ibmcsidriver/node.go:186","msg":"CSINodeServer-NodePublishVolume response...","RequestID":"","Response":{}}
    node_test.go:200: Test case: Empty volume ID
{"level":"info","ts":"2021-07-29T02:05:23.621-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"staging_target_path":"/staging","target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:23.621-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000000876}
{"level":"error","ts":"2021-07-29T02:05:23.621-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    node_test.go:200: Test case: Empty staging target path
{"level":"info","ts":"2021-07-29T02:05:23.622-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"testvolumeid","target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:23.622-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000000839}
{"level":"error","ts":"2021-07-29T02:05:23.622-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: NoStagingTargetPath, Description: Staging target path not provided, Action: Please check if there is any error in POD describe related with volume attach}"}
    node_test.go:200: Test case: Empty target path
{"level":"info","ts":"2021-07-29T02:05:23.623-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"testvolumeid","staging_target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:23.623-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000000883}
{"level":"error","ts":"2021-07-29T02:05:23.623-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: NoTargetPath, Description: Target path must be provided, Action: Please check if there is any error in POD describe related with volume attach}"}
    node_test.go:200: Test case: Empty volume capabilities
{"level":"info","ts":"2021-07-29T02:05:23.623-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"testvolumeid","staging_target_path":"/staging","target_path":"/mnt/test"}}
{"level":"info","ts":"2021-07-29T02:05:23.624-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000000923}
{"level":"error","ts":"2021-07-29T02:05:23.624-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: NoVolumeCapabilities, Description: Volume capabilities must be provided, Action: Please provide volume capabilities in the storage class before creating volume}"}
    node_test.go:200: Test case: Not supported volume capabilities
{"level":"info","ts":"2021-07-29T02:05:23.624-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"testvolumeid","staging_target_path":"/staging","target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":5}}}}
{"level":"info","ts":"2021-07-29T02:05:23.624-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000000895}
{"level":"error","ts":"2021-07-29T02:05:23.624-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: VolumeCapabilitiesNotSupported, Description: Volume capabilities not supported, Action: Please provide valid volume capabilities while creating volume}"}
    node_test.go:200: Test case: Raw block request with validdevice
{"level":"info","ts":"2021-07-29T02:05:23.625-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"csiprovidervolumeid","publish_context":{"device-path":"/dev/sda"},"staging_target_path":"/staging","target_path":"/mnt/test","volume_capability":{"AccessType":{"Block":{}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:23.625-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000000825}
{"level":"info","ts":"2021-07-29T02:05:23.626-0700","caller":"ibmcsidriver/node_helper.go:99","msg":"CSINodeServer-processMountForBlock","RequestID":"","devicePath":"/dev/sda","target":"/mnt/test","options":["bind"]}
{"level":"info","ts":"2021-07-29T02:05:23.626-0700","caller":"ibmcsidriver/node_helper.go:34","msg":"CSINodeServer-findDevicePathSource...","RequestID":""}
{"level":"warn","ts":"2021-07-29T02:05:23.626-0700","caller":"ibmcsidriver/node_helper.go:37","msg":"Device path not found, trying to fix by udevadm trigger","RequestID":"","DevicePath":"/dev/sda"}
{"level":"info","ts":"2021-07-29T02:05:23.626-0700","caller":"ibmcsidriver/node_helper.go:147","msg":"CSINodeServer-udevadmTrigger refreshing all devices...","RequestID":""}
{"level":"info","ts":"2021-07-29T02:05:43.683-0700","caller":"ibmcsidriver/node_helper.go:159","msg":"udevadmTrigger: Successfully executed udevadm trigger to referesh all devices.","RequestID":""}
{"level":"warn","ts":"2021-07-29T02:05:43.683-0700","caller":"ibmcsidriver/node_helper.go:51","msg":"Device Path is nvme. Try to find nvme device","RequestID":""}
{"level":"info","ts":"2021-07-29T02:05:43.684-0700","caller":"ibmcsidriver/node_helper.go:110","msg":"Found device path ","RequestID":"","devicePath":"/dev/sda","source":"/dev/sda"}
{"level":"info","ts":"2021-07-29T02:05:43.684-0700","caller":"ibmcsidriver/node_helper.go:125","msg":"Making target file","RequestID":"","target":"/mnt/test"}
{"level":"info","ts":"2021-07-29T02:05:43.685-0700","caller":"ibmcsidriver/node_helper.go:134","msg":"Mounting source to target","RequestID":"","source":"/dev/sda","target":"/mnt/test"}
{"level":"info","ts":"2021-07-29T02:05:43.685-0700","caller":"ibmcsidriver/node_helper.go:142","msg":"Block volume mounted successfully","RequestID":"","source":"/dev/sda","target":"/mnt/test"}
{"level":"info","ts":"2021-07-29T02:05:43.685-0700","caller":"ibmcsidriver/node.go:186","msg":"CSINodeServer-NodePublishVolume response...","RequestID":"","Response":{}}
    node_test.go:200: Test case: Raw block request with invaliddevice
{"level":"info","ts":"2021-07-29T02:05:43.687-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"csiprovidervolumeid","publish_context":{"device-path":""},"staging_target_path":"/staging","target_path":"/mnt/test","volume_capability":{"AccessType":{"Block":{}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:43.687-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.000001607}
{"level":"info","ts":"2021-07-29T02:05:43.688-0700","caller":"ibmcsidriver/node_helper.go:99","msg":"CSINodeServer-processMountForBlock","RequestID":"","devicePath":"","target":"/mnt/test","options":["bind"]}
{"level":"error","ts":"2021-07-29T02:05:43.688-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: EmptyDevicePath, Description: Staging device path must be provided, Action: Please check if there is any error in POD describe related with volume attach}"}
{"level":"info","ts":"2021-07-29T02:05:43.689-0700","caller":"ibmcsidriver/node.go:186","msg":"CSINodeServer-NodePublishVolume response...","RequestID":"","Response":null,"error":"rpc error: code = InvalidArgument desc = {RequestID:  , Code: EmptyDevicePath, Description: Staging device path must be provided, Action: Please check if there is any error in POD describe related with volume attach}"}
    node_test.go:200: Test case: Raw block request with invalidTarget
{"level":"info","ts":"2021-07-29T02:05:43.689-0700","caller":"ibmcsidriver/node.go:118","msg":"CSINodeServer-NodePublishVolume...","RequestID":"","Request":{"volume_id":"csiprovidervolumeid","publish_context":{"device-path":"/dev/sda"},"staging_target_path":"/staging","volume_capability":{"AccessType":{"Block":{}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:43.689-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodePublishVolume":0.00000135}
{"level":"error","ts":"2021-07-29T02:05:43.690-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: NoTargetPath, Description: Target path must be provided, Action: Please check if there is any error in POD describe related with volume attach}"}
--- PASS: TestNodePublishVolume (20.07s)
=== RUN   TestNodeUnpublishVolume
    node_test.go:253: Test case: Valid request
{"level":"info","ts":"2021-07-29T02:05:43.693-0700","caller":"ibmcsidriver/node.go:193","msg":"CSINodeServer-NodeUnpublishVolume...","RequestID":"5dd0af0e-8152-4330-a8c9-26b587d7f028","Request":{"volume_id":"csiprovidervolumeid","target_path":"/mnt/test"}}
{"level":"info","ts":"2021-07-29T02:05:43.693-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"5dd0af0e-8152-4330-a8c9-26b587d7f028","NodeUnpublishVolume":0.000001104}
{"level":"info","ts":"2021-07-29T02:05:43.693-0700","caller":"ibmcsidriver/node.go:207","msg":"Unmounting  target path","RequestID":"5dd0af0e-8152-4330-a8c9-26b587d7f028","targetPath":"/mnt/test"}
{"level":"info","ts":"2021-07-29T02:05:43.697-0700","caller":"ibmcsidriver/node.go:214","msg":"Successfully unmounted  target path","RequestID":"5dd0af0e-8152-4330-a8c9-26b587d7f028","targetPath":"/mnt/test"}
    node_test.go:253: Test case: Empty volume ID
{"level":"info","ts":"2021-07-29T02:05:43.697-0700","caller":"ibmcsidriver/node.go:193","msg":"CSINodeServer-NodeUnpublishVolume...","RequestID":"59386315-eca8-4a11-bfb5-f5c35854e1b6","Request":{"target_path":"/mnt/test"}}
{"level":"info","ts":"2021-07-29T02:05:43.697-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"59386315-eca8-4a11-bfb5-f5c35854e1b6","NodeUnpublishVolume":0.000000558}
{"level":"error","ts":"2021-07-29T02:05:43.697-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"59386315-eca8-4a11-bfb5-f5c35854e1b6","error":"{RequestID: 59386315-eca8-4a11-bfb5-f5c35854e1b6 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    node_test.go:253: Test case: Empty target path
{"level":"info","ts":"2021-07-29T02:05:43.698-0700","caller":"ibmcsidriver/node.go:193","msg":"CSINodeServer-NodeUnpublishVolume...","RequestID":"b3d12e24-4d57-4c6e-9e94-580d16de3dfb","Request":{"volume_id":"csiprovidervolumeid"}}
{"level":"info","ts":"2021-07-29T02:05:43.699-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"b3d12e24-4d57-4c6e-9e94-580d16de3dfb","NodeUnpublishVolume":0.000000425}
{"level":"error","ts":"2021-07-29T02:05:43.699-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"b3d12e24-4d57-4c6e-9e94-580d16de3dfb","error":"{RequestID: b3d12e24-4d57-4c6e-9e94-580d16de3dfb , Code: NoTargetPath, Description: Target path must be provided, Action: Please check if there is any error in POD describe related with volume attach}"}
--- PASS: TestNodeUnpublishVolume (0.01s)
=== RUN   TestNodeStageVolume
    node_test.go:352: Test case: Valid request
{"level":"info","ts":"2021-07-29T02:05:43.700-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"volume_id":"newstagevolumeID","publish_context":{"device-path":"/dev"},"staging_target_path":"/staging","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:05:43.701-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000000696}
{"level":"info","ts":"2021-07-29T02:05:43.701-0700","caller":"ibmcsidriver/node_helper.go:34","msg":"CSINodeServer-findDevicePathSource...","RequestID":""}
{"level":"warn","ts":"2021-07-29T02:05:43.701-0700","caller":"ibmcsidriver/node_helper.go:37","msg":"Device path not found, trying to fix by udevadm trigger","RequestID":"","DevicePath":"/dev"}
{"level":"info","ts":"2021-07-29T02:05:43.701-0700","caller":"ibmcsidriver/node_helper.go:147","msg":"CSINodeServer-udevadmTrigger refreshing all devices...","RequestID":""}
{"level":"info","ts":"2021-07-29T02:06:03.758-0700","caller":"ibmcsidriver/node_helper.go:159","msg":"udevadmTrigger: Successfully executed udevadm trigger to referesh all devices.","RequestID":""}
{"level":"warn","ts":"2021-07-29T02:06:03.758-0700","caller":"ibmcsidriver/node_helper.go:51","msg":"Device Path is nvme. Try to find nvme device","RequestID":""}
{"level":"info","ts":"2021-07-29T02:06:03.758-0700","caller":"ibmcsidriver/node.go:264","msg":"Found device path ","RequestID":"","devicePath":"/dev","source":"/dev"}
{"level":"info","ts":"2021-07-29T02:06:03.759-0700","caller":"ibmcsidriver/node.go:275","msg":"Creating target directory ","RequestID":"","stagingTargetPath":"/staging"}
{"level":"info","ts":"2021-07-29T02:06:03.759-0700","caller":"ibmcsidriver/node.go:303","msg":"Formating and mounting ","RequestID":"","source":"/dev","stagingTargetPath":"/staging","fsType":"ext2","options":null}
    node_test.go:352: Test case: Empty volume ID
{"level":"info","ts":"2021-07-29T02:06:03.767-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"publish_context":{"device-path":"/dev"},"staging_target_path":"/staging","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:06:03.768-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000001761}
{"level":"error","ts":"2021-07-29T02:06:03.768-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    node_test.go:352: Test case: Empty target path
{"level":"info","ts":"2021-07-29T02:06:03.768-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"volume_id":"newstagevolumeID","publish_context":{"device-path":"/dev"},"volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:06:03.769-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000001069}
{"level":"error","ts":"2021-07-29T02:06:03.769-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: NoStagingTargetPath, Description: Staging target path not provided, Action: Please check if there is any error in POD describe related with volume attach}"}
    node_test.go:352: Test case: Empty volume capabilities
{"level":"info","ts":"2021-07-29T02:06:03.769-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"volume_id":"newstagevolumeID","publish_context":{"device-path":"/dev"},"staging_target_path":"/mnt/test"}}
{"level":"info","ts":"2021-07-29T02:06:03.769-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000000922}
{"level":"error","ts":"2021-07-29T02:06:03.769-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: NoVolumeCapabilities, Description: Volume capabilities must be provided, Action: Please provide volume capabilities in the storage class before creating volume}"}
    node_test.go:352: Test case: Not supported volume capabilities
{"level":"info","ts":"2021-07-29T02:06:03.770-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"volume_id":"newstagevolumeID","publish_context":{"device-path":"/dev"},"staging_target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":5}}}}
{"level":"info","ts":"2021-07-29T02:06:03.770-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000000641}
{"level":"error","ts":"2021-07-29T02:06:03.770-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: VolumeCapabilitiesNotSupported, Description: Volume capabilities not supported, Action: Please provide valid volume capabilities while creating volume}"}
    node_test.go:352: Test case: Empty device path in the context
{"level":"info","ts":"2021-07-29T02:06:03.771-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"volume_id":"newstagevolumeID","publish_context":{"device-path":""},"staging_target_path":"/mnt/test","volume_capability":{"AccessType":{"Mount":{"fs_type":"ext2"}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:06:03.771-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000000871}
{"level":"error","ts":"2021-07-29T02:06:03.771-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"","error":"{RequestID:  , Code: EmptyDevicePath, Description: Staging device path must be provided, Action: Please check if there is any error in POD describe related with volume attach}"}
    node_test.go:352: Test case: Valid raw block StageVolume request
{"level":"info","ts":"2021-07-29T02:06:03.771-0700","caller":"ibmcsidriver/node.go:223","msg":"CSINodeServer-NodeStageVolume...","RequestID":"","Request":{"volume_id":"newstagevolumeID","publish_context":{"device-path":"/dev/sda"},"staging_target_path":"/staging","volume_capability":{"AccessType":{"Block":{}},"access_mode":{"mode":1}}}}
{"level":"info","ts":"2021-07-29T02:06:03.772-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"","NodeStageVolume":0.000000351}
--- PASS: TestNodeStageVolume (20.07s)
=== RUN   TestNodeUnstageVolume
    node_test.go:404: Test case: Valid request
{"level":"info","ts":"2021-07-29T02:06:03.773-0700","caller":"ibmcsidriver/node.go:316","msg":"CSINodeServer-NodeUnstageVolume ... ","RequestID":"5ef7dc9e-5f55-4496-9d97-b1c654a0ac1c","Request":{"volume_id":"csiprovidervolumeid","staging_target_path":"/mnt/test"}}
{"level":"info","ts":"2021-07-29T02:06:03.773-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"5ef7dc9e-5f55-4496-9d97-b1c654a0ac1c","NodeUnstageVolume":0.000000639}
{"level":"info","ts":"2021-07-29T02:06:03.774-0700","caller":"ibmcsidriver/node.go:331","msg":"Unmounting staging target path","RequestID":"5ef7dc9e-5f55-4496-9d97-b1c654a0ac1c","stagingTargetPath":"/mnt/test"}
{"level":"info","ts":"2021-07-29T02:06:03.774-0700","caller":"ibmcsidriver/node.go:337","msg":"Successfully Unmounted staging target path","RequestID":"5ef7dc9e-5f55-4496-9d97-b1c654a0ac1c","stagingTargetPath":"/mnt/test"}
    node_test.go:404: Test case: Empty volume ID
{"level":"info","ts":"2021-07-29T02:06:03.774-0700","caller":"ibmcsidriver/node.go:316","msg":"CSINodeServer-NodeUnstageVolume ... ","RequestID":"a43f7373-dc5b-444c-b914-06c177f2692f","Request":{"staging_target_path":"/staging"}}
{"level":"info","ts":"2021-07-29T02:06:03.774-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"a43f7373-dc5b-444c-b914-06c177f2692f","NodeUnstageVolume":0.000000494}
{"level":"error","ts":"2021-07-29T02:06:03.774-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"a43f7373-dc5b-444c-b914-06c177f2692f","error":"{RequestID: a43f7373-dc5b-444c-b914-06c177f2692f , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    node_test.go:404: Test case: Empty target path
{"level":"info","ts":"2021-07-29T02:06:03.774-0700","caller":"ibmcsidriver/node.go:316","msg":"CSINodeServer-NodeUnstageVolume ... ","RequestID":"0f72d4aa-c3e4-4279-b7c8-7a88e0be4714","Request":{"volume_id":"csiprovidervolumeid"}}
{"level":"info","ts":"2021-07-29T02:06:03.774-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"0f72d4aa-c3e4-4279-b7c8-7a88e0be4714","NodeUnstageVolume":0.000000439}
{"level":"error","ts":"2021-07-29T02:06:03.775-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"0f72d4aa-c3e4-4279-b7c8-7a88e0be4714","error":"{RequestID: 0f72d4aa-c3e4-4279-b7c8-7a88e0be4714 , Code: NoStagingTargetPath, Description: Staging target path not provided, Action: Please check if there is any error in POD describe related with volume attach}"}
--- PASS: TestNodeUnstageVolume (0.00s)
=== RUN   TestNodeGetCapabilities
{"level":"info","ts":"2021-07-29T02:06:03.777-0700","caller":"ibmcsidriver/node.go:345","msg":"CSINodeServer-NodeGetCapabilities... ","RequestID":"2a7325a4-55c6-4b1a-88d9-743baaf1eb87","Request":{}}
--- PASS: TestNodeGetCapabilities (0.00s)
=== RUN   TestNodeGetInfo
{"level":"info","ts":"2021-07-29T02:06:03.778-0700","caller":"ibmcsidriver/node.go:355","msg":"CSINodeServer-NodeGetInfo... ","RequestID":"0f429a25-18a6-40a1-9d83-e20d37a83388","Request":{}}
{"level":"info","ts":"2021-07-29T02:06:03.778-0700","caller":"ibmcsidriver/node.go:382","msg":"Number of cores of the node and attachable volume limits.","RequestID":"0f429a25-18a6-40a1-9d83-e20d37a83388","Cores":8,"AttachableVolumeLimits":12}
{"level":"info","ts":"2021-07-29T02:06:03.778-0700","caller":"ibmcsidriver/node.go:389","msg":"NodeGetInfoResponse","RequestID":"0f429a25-18a6-40a1-9d83-e20d37a83388","NodeGetInfoResponse":{"node_id":"testworker","max_volumes_per_node":12,"accessible_topology":{"segments":{"failure-domain.beta.kubernetes.io/region":"testregion","failure-domain.beta.kubernetes.io/zone":"testzone"}}}}
{"level":"info","ts":"2021-07-29T02:06:03.779-0700","caller":"ibmcsidriver/node.go:355","msg":"CSINodeServer-NodeGetInfo... ","RequestID":"61bdc387-9bea-47f6-bcbf-a8850051f9ca","Request":{}}
{"level":"error","ts":"2021-07-29T02:06:03.779-0700","caller":"ibmcsidriver/node.go:364","msg":"Failed to initialize node metadata","RequestID":"61bdc387-9bea-47f6-bcbf-a8850051f9ca","error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"}
{"level":"error","ts":"2021-07-29T02:06:03.779-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"61bdc387-9bea-47f6-bcbf-a8850051f9ca","error":"{RequestID: 61bdc387-9bea-47f6-bcbf-a8850051f9ca , Code: NodeMetadataInitFailed, Description: Failed to initialize node metadata, BackendError: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined, Action: Please check the node labels as per BackendError, accordingly you may add the labels manually}"}
--- PASS: TestNodeGetInfo (0.00s)
=== RUN   TestNodeGetVolumeStats
    node_test.go:584: Test case: Mode is block
usage:<total:1 unit:BYTES > 
{"level":"info","ts":"2021-07-29T02:06:03.781-0700","caller":"ibmcsidriver/node.go:397","msg":"CSINodeServer-NodeGetVolumeStats... ","RequestID":"e1ed0f69-1ba9-4e27-b827-df1115b8f68b","Request":{"volume_id":"csiprovidervolumeid","volume_path":"/var/volpath"}}
{"level":"info","ts":"2021-07-29T02:06:03.781-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"e1ed0f69-1ba9-4e27-b827-df1115b8f68b","NodeGetVolumeStats":0.000000526}
{"level":"info","ts":"2021-07-29T02:06:03.781-0700","caller":"ibmcsidriver/node.go:434","msg":"Response for Volume stats","RequestID":"e1ed0f69-1ba9-4e27-b827-df1115b8f68b","Response":{"usage":[{"total":1,"unit":1}]}}
    node_test.go:584: Test case: Empty volume ID
<nil>
{"level":"info","ts":"2021-07-29T02:06:03.782-0700","caller":"ibmcsidriver/node.go:397","msg":"CSINodeServer-NodeGetVolumeStats... ","RequestID":"47fa2b25-9732-4fc1-a547-3a0f61fda1b6","Request":{"volume_path":"/var/volpath"}}
{"level":"info","ts":"2021-07-29T02:06:03.782-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"47fa2b25-9732-4fc1-a547-3a0f61fda1b6","NodeGetVolumeStats":0.000000409}
{"level":"error","ts":"2021-07-29T02:06:03.782-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"47fa2b25-9732-4fc1-a547-3a0f61fda1b6","error":"{RequestID: 47fa2b25-9732-4fc1-a547-3a0f61fda1b6 , Code: EmptyVolumeID, Description: VolumeID must be provided, Action: Please provide volume ID for attach/detach or delete it}"}
    node_test.go:584: Test case: Empty volume path
<nil>
{"level":"info","ts":"2021-07-29T02:06:03.782-0700","caller":"ibmcsidriver/node.go:397","msg":"CSINodeServer-NodeGetVolumeStats... ","RequestID":"1f559486-2b36-4cba-b63d-10d5833b253e","Request":{"volume_id":"csiprovidervolumeid"}}
{"level":"info","ts":"2021-07-29T02:06:03.783-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"1f559486-2b36-4cba-b63d-10d5833b253e","NodeGetVolumeStats":0.000000516}
{"level":"error","ts":"2021-07-29T02:06:03.783-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"1f559486-2b36-4cba-b63d-10d5833b253e","error":"{RequestID: 1f559486-2b36-4cba-b63d-10d5833b253e , Code: EmptyVolumePath, Description: Volume path can not be empty, Action: Please check if volume is used by POD properly}"}
    node_test.go:584: Test case: Mode is File
usage:<available:1 total:1 used:1 unit:BYTES > usage:<available:1 total:1 used:1 unit:INODES > 
{"level":"info","ts":"2021-07-29T02:06:03.783-0700","caller":"ibmcsidriver/node.go:397","msg":"CSINodeServer-NodeGetVolumeStats... ","RequestID":"c6a40307-7c0d-400b-98a0-7c1106acb738","Request":{"volume_id":"csiprovidervolumeid","volume_path":"/for/notblocktest"}}
{"level":"info","ts":"2021-07-29T02:06:03.783-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"c6a40307-7c0d-400b-98a0-7c1106acb738","NodeGetVolumeStats":0.000000446}
{"level":"info","ts":"2021-07-29T02:06:03.783-0700","caller":"ibmcsidriver/node.go:460","msg":"Response for Volume stats","RequestID":"c6a40307-7c0d-400b-98a0-7c1106acb738","Response":{"usage":[{"available":1,"total":1,"used":1,"unit":1},{"available":1,"total":1,"used":1,"unit":2}]}}
    node_test.go:584: Test case: Error in checking block device
<nil>
{"level":"info","ts":"2021-07-29T02:06:03.783-0700","caller":"ibmcsidriver/node.go:397","msg":"CSINodeServer-NodeGetVolumeStats... ","RequestID":"054dce28-160a-420b-9fe2-3933719ef4b2","Request":{"volume_id":"csiprovidervolumeid","volume_path":"/for/errorblock"}}
{"level":"info","ts":"2021-07-29T02:06:03.783-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"054dce28-160a-420b-9fe2-3933719ef4b2","NodeGetVolumeStats":0.000000493}
{"level":"error","ts":"2021-07-29T02:06:03.784-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"054dce28-160a-420b-9fe2-3933719ef4b2","error":"{RequestID: 054dce28-160a-420b-9fe2-3933719ef4b2 , Code: BlockDeviceCheckFailed, Description: Failed to determine if volume 'csiprovidervolumeid' is block device or not, BackendError: error in IsBlockDevice check, Action: Please check if volume is used by POD properly}"}
    node_test.go:584: Test case: Failed to get block size
<nil>
{"level":"info","ts":"2021-07-29T02:06:03.784-0700","caller":"ibmcsidriver/node.go:397","msg":"CSINodeServer-NodeGetVolumeStats... ","RequestID":"959b2b14-d2e2-4d6a-a7ea-5462c3870622","Request":{"volume_id":"csiprovidervolumeid","volume_path":"/for/errordevicepath"}}
{"level":"info","ts":"2021-07-29T02:06:03.784-0700","caller":"metrics/metrics.go:99","msg":"Time to complete","RequestID":"959b2b14-d2e2-4d6a-a7ea-5462c3870622","NodeGetVolumeStats":0.000000322}
{"level":"error","ts":"2021-07-29T02:06:03.784-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"959b2b14-d2e2-4d6a-a7ea-5462c3870622","error":"{RequestID: 959b2b14-d2e2-4d6a-a7ea-5462c3870622 , Code: GetDeviceInfoFailed, Description: Failed to get device info, BackendError: error in getting device info, Action: Please check if volume is used by POD properly}"}
--- PASS: TestNodeGetVolumeStats (0.00s)
=== RUN   TestNodeExpandVolume
    node_test.go:657: Test case: Empty volume Path
{"level":"info","ts":"2021-07-29T02:06:03.786-0700","caller":"ibmcsidriver/node.go:467","msg":"CSINodeServer-NodeExpandVolume","RequestID":"b7a9d457-e2ae-4442-b99c-13cd8cf3081d","Request":{"volume_id":"csiprovidervolumeid"}}
{"level":"error","ts":"2021-07-29T02:06:03.786-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"b7a9d457-e2ae-4442-b99c-13cd8cf3081d","error":"{RequestID: b7a9d457-e2ae-4442-b99c-13cd8cf3081d , Code: EmptyVolumePath, Description: Volume path can not be empty, Action: Please check if volume is used by POD properly}"}
    node_test.go:657: Test case: Invalid volumePath
{"level":"info","ts":"2021-07-29T02:06:03.786-0700","caller":"ibmcsidriver/node.go:467","msg":"CSINodeServer-NodeExpandVolume","RequestID":"f4ef50e1-bf92-4212-b7b3-862f08654985","Request":{"volume_id":"csiprovidervolumeid","volume_path":"/invalid-volPath"}}
{"level":"error","ts":"2021-07-29T02:06:03.786-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"f4ef50e1-bf92-4212-b7b3-862f08654985","error":"{RequestID: f4ef50e1-bf92-4212-b7b3-862f08654985 , Code: ObjectNotFound, Description: Object not found%!(EXTRA string=/invalid-volPath), BackendError: stat /invalid-volPath: no such file or directory, Action: Please check 'BackendError' tag for more details}"}
    node_test.go:657: Test case: valid volumePath
{"level":"info","ts":"2021-07-29T02:06:03.786-0700","caller":"ibmcsidriver/node.go:467","msg":"CSINodeServer-NodeExpandVolume","RequestID":"dcbce45e-94c7-455c-b9ac-c3aa4a19e827","Request":{"volume_id":"csiprovidervolumeid","volume_path":"valid-vol-path","capacity_range":{"required_bytes":21474836480}}}
    node_test.go:657: Test case: volumePath not mounted
{"level":"info","ts":"2021-07-29T02:06:03.787-0700","caller":"ibmcsidriver/node.go:467","msg":"CSINodeServer-NodeExpandVolume","RequestID":"9584b651-7d81-4ec7-94a3-355da473c2df","Request":{"volume_id":"csiprovidervolumeid","volume_path":"fake-volPath"}}
{"level":"error","ts":"2021-07-29T02:06:03.787-0700","caller":"messages/messages.go:62","msg":"FAILED CSI ERROR","RequestID":"9584b651-7d81-4ec7-94a3-355da473c2df","error":"{RequestID: 9584b651-7d81-4ec7-94a3-355da473c2df , Code: ObjectNotFound, Description: Object not found%!(EXTRA string=fake-volPath), BackendError: stat fake-volPath: no such file or directory, Action: Please check 'BackendError' tag for more details}"}
--- PASS: TestNodeExpandVolume (0.00s)
=== RUN   TestIsBlockDevice
    node_test.go:699: test case: Not a valid path, hence its not block device
    node_test.go:699: test case: Valid path but not a block device
--- PASS: TestIsBlockDevice (0.00s)
=== RUN   TestIsDevicePathNotExist
    node_test.go:730: test case: Success device path not exists
    node_test.go:730: test case: Device path exists
--- PASS: TestIsDevicePathNotExist (0.00s)
=== RUN   TestDeviceInfo
    node_test.go:756: test case: Success device info
    node_test.go:756: test case: Failed device info
--- PASS: TestDeviceInfo (0.01s)
=== RUN   TestSetup
    server_test.go:41: Good setup
    server_test.go:53: Wrong endpoint format
    server_test.go:58: ---------> error parse "---:/tmp/testcsi.sock": first path segment in URL cannot contain colon
    server_test.go:62: Wrong Scheme
    server_test.go:66: ---------> error Endpoint scheme not supported
    server_test.go:70: tcp Scheme
    server_test.go:74: ---------> error <nil>
    server_test.go:79: Wrong address
    server_test.go:83: ---------> error <nil>
--- PASS: TestSetup (0.00s)
=== RUN   TestLogGRPC
    server_test.go:88: TODO:~ TestLogGRPC
--- PASS: TestLogGRPC (0.00s)
PASS
coverage: 86.8% of statements
ok  	github.com/IBM/ibm-vpc-block-csi-driver/pkg/ibmcsidriver	121.025s	coverage: 86.8% of statements
docker build --build-arg TAG="fef39458ca46a85061e09df0648a06ae1f86a1ed" --build-arg OS=linux --build-arg ARCH=amd64 -t csi-driver-builder --pull -f Dockerfile.builder .
Sending build context to Docker daemon  40.24MB
Step 1/7 : FROM golang:1.16
1.16: Pulling from library/golang
Digest: sha256:4544ae57fc735d7e415603d194d9fb09589b8ad7acd4d66e928eabfb1ed85ff1
Status: Image is up to date for golang:1.16
 ---> 028d102f774a
Step 2/7 : WORKDIR /go/src/github.com/IBM/ibm-vpc-block-csi-driver
 ---> Using cache
 ---> 70c8ab754c7a
Step 3/7 : ADD . /go/src/github.com/IBM/ibm-vpc-block-csi-driver
 ---> b3966c0e94ca
Step 4/7 : ARG TAG
 ---> Running in 248bde241a65
Removing intermediate container 248bde241a65
 ---> dceef21d194f
Step 5/7 : ARG OS
 ---> Running in f9c3b1f5346f
Removing intermediate container f9c3b1f5346f
 ---> fa85f0dfa5c0
Step 6/7 : ARG ARCH
 ---> Running in 317ee4c452c2
Removing intermediate container 317ee4c452c2
 ---> 95d2dda46993
Step 7/7 : CMD ["./scripts/build-bin.sh"]
 ---> Running in fed308e51780
Removing intermediate container fed308e51780
 ---> f734287c2047
Successfully built f734287c2047
Successfully tagged csi-driver-builder:latest
docker run --env GHE_TOKEN= csi-driver-builder
+ cd /go/src/github.com/IBM/ibm-vpc-block-csi-driver
+ CGO_ENABLED=0
+ go build -a -ldflags '-X main.vendorVersion=vpcBlockDriver- -extldflags "-static"' -o /go/bin/ibm-vpc-block-csi-driver ./cmd/
go: downloading github.com/IBM/ibm-csi-common v1.0.0-beta3
go: downloading github.com/IBM/ibmcloud-volume-interface v1.0.0-beta7
go: downloading github.com/prometheus/client_golang v1.7.1
go: downloading go.uber.org/zap v1.15.0
go: downloading github.com/container-storage-interface/spec v1.3.0
go: downloading github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading golang.org/x/net v0.0.0-20201209123823-ac852fbbde11
go: downloading golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d
go: downloading google.golang.org/grpc v1.34.0
go: downloading k8s.io/kubernetes v1.14.2
go: downloading github.com/BurntSushi/toml v0.3.1
go: downloading github.com/kelseyhightower/envconfig v1.4.0
go: downloading github.com/satori/go.uuid v1.2.0
go: downloading github.com/IBM/ibmcloud-volume-vpc v1.0.0-beta9
go: downloading k8s.io/api v0.0.0-20190516230258-a675ac48af67
go: downloading k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1
go: downloading k8s.io/client-go v11.0.1-0.20190516230509-ae8359b20417+incompatible
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.10.0
go: downloading github.com/golang/protobuf v1.4.3
go: downloading go.uber.org/atomic v1.6.0
go: downloading go.uber.org/multierr v1.5.0
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.1.1
go: downloading github.com/prometheus/procfs v0.1.3
go: downloading google.golang.org/protobuf v1.25.0
go: downloading github.com/gogo/protobuf v1.1.1
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: downloading k8s.io/klog v0.3.1
go: downloading k8s.io/utils v0.0.0-20210305010621-2afb4311ab10
go: downloading github.com/imdario/mergo v0.3.7
go: downloading github.com/spf13/pflag v1.0.3
go: downloading golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
go: downloading google.golang.org/genproto v0.0.0-20201209185603-f92720507ed4
go: downloading github.com/google/gofuzz v1.0.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading github.com/dgrijalva/jwt-go v3.2.0+incompatible
go: downloading gopkg.in/inf.v0 v0.9.0
go: downloading github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
go: downloading golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
go: downloading k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
go: downloading github.com/hashicorp/golang-lru v0.5.1
go: downloading k8s.io/klog/v2 v2.4.0
go: downloading github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.6.7
go: downloading github.com/json-iterator/go v1.1.10
go: downloading github.com/modern-go/reflect2 v1.0.1
go: downloading sigs.k8s.io/yaml v1.1.0
go: downloading golang.org/x/text v0.3.4
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/fatih/structs v1.1.0
go: downloading github.com/go-logr/logr v0.3.0
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
docker cp `docker ps -q -n=1`:/go/bin/ibm-vpc-block-csi-driver ./ibm-vpc-block-csi-driver
docker build	\
        --build-arg git_commit_id="fef39458ca46a85061e09df0648a06ae1f86a1ed" \
        --build-arg git_remote_url="https://github.com/IBM/ibm-vpc-block-csi-driver.git" \
        --build-arg build_date="2021-07-29T09:06:48Z" \
        --build-arg jenkins_build_number=unknown \
        --build-arg REPO_SOURCE_URL= \
        --build-arg BUILD_URL= \
        --build-arg PROXY_IMAGE_URL= \
-t contsto2/ibm-vpc-block-csi-driver:latest-amd64 -f Dockerfile .
Sending build context to Docker daemon  40.24MB
Step 1/19 : FROM ubuntu:16.04
 ---> 9ff95a467e45
Step 2/19 : ARG git_commit_id=unknown
 ---> Using cache
 ---> 651a0b68f682
Step 3/19 : ARG git_remote_url=unknown
 ---> Using cache
 ---> a5d7a10682a5
Step 4/19 : ARG build_date=unknown
 ---> Using cache
 ---> 972e72c6347d
Step 5/19 : ARG jenkins_build_number=unknown
 ---> Using cache
 ---> b8732bf3f968
Step 6/19 : ARG REPO_SOURCE_URL=blank
 ---> Using cache
 ---> 104ba9b29ad0
Step 7/19 : ARG BUILD_URL=blank
 ---> Using cache
 ---> dedc973a4cb5
Step 8/19 : LABEL git-commit-id=${git_commit_id}
 ---> Using cache
 ---> 378c05797df5
Step 9/19 : LABEL git-remote-url=${git_remote_url}
 ---> Using cache
 ---> 143c4ee82ea4
Step 10/19 : LABEL build-date=${build_date}
 ---> Running in e06922fb42f3
Removing intermediate container e06922fb42f3
 ---> 5759137b670d
Step 11/19 : LABEL jenkins-build-number=${jenkins_build_number}
 ---> Running in 938f5de10b99
Removing intermediate container 938f5de10b99
 ---> c07abbe5b857
Step 12/19 : LABEL razee.io/source-url="${REPO_SOURCE_URL}"
 ---> Running in c642cd5fe141
Removing intermediate container c642cd5fe141
 ---> 9cac482fbdfa
Step 13/19 : LABEL razee.io/build-url="${BUILD_URL}"
 ---> Running in c6f287fb5ba7
Removing intermediate container c6f287fb5ba7
 ---> a214afcc1dcb
Step 14/19 : RUN apt-get update && apt-get install -y --no-install-recommends nfs-common &&    apt-get install -y udev &&          apt-get install -y --no-install-recommends apt &&  	apt-get install -y --no-install-recommends ca-certificates xfsprogs &&  	apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 ---> Running in 49daee8ffc6b
Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]
Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Get:4 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [2051 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
Get:6 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]
Get:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [15.9 kB]
Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [984 kB]
Get:9 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [8820 B]
Get:10 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [2559 kB]
Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [16.4 kB]
Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [1544 kB]
Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [26.2 kB]
Get:17 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [10.9 kB]
Get:18 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [12.7 kB]
Fetched 19.4 MB in 16s (1161 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  keyutils libasn1-8-heimdal libevent-2.0-5 libffi6 libgmp10 libgnutls30
  libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhogweed4 libhx509-5-heimdal libidn11 libk5crypto3
  libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  libnettle6 libnfsidmap2 libp11-kit0 libroken18-heimdal libsasl2-2
  libsasl2-modules-db libsqlite3-0 libtasn1-6 libtirpc1 libwind0-heimdal
  libwrap0 rpcbind ucf
Suggested packages:
  gnutls-bin krb5-doc krb5-user open-iscsi watchdog
Recommended packages:
  krb5-locales libsasl2-modules tcpd python
The following NEW packages will be installed:
  keyutils libasn1-8-heimdal libevent-2.0-5 libffi6 libgmp10 libgnutls30
  libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhogweed4 libhx509-5-heimdal libidn11 libk5crypto3
  libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  libnettle6 libnfsidmap2 libp11-kit0 libroken18-heimdal libsasl2-2
  libsasl2-modules-db libsqlite3-0 libtasn1-6 libtirpc1 libwind0-heimdal
  libwrap0 nfs-common rpcbind ucf
0 upgraded, 34 newly installed, 0 to remove and 5 not upgraded.
Need to get 3759 kB of archives.
After this operation, 12.1 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libgmp10 amd64 2:6.1.0+dfsg-2 [240 kB]
Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnettle6 amd64 3.2-1ubuntu0.16.04.2 [93.7 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libhogweed4 amd64 3.2-1ubuntu0.16.04.2 [136 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libidn11 amd64 1.32-3ubuntu1.2 [46.5 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 libffi6 amd64 3.2.1-4 [17.8 kB]
Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libp11-kit0 amd64 0.23.2-5~ubuntu16.04.2 [107 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libtasn1-6 amd64 4.7-3ubuntu0.16.04.3 [43.5 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgnutls30 amd64 3.4.10-4ubuntu1.8 [548 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libroken18-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [41.4 kB]
Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libasn1-8-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [174 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libhcrypto4-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [85.0 kB]
Get:12 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libheimbase1-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [29.3 kB]
Get:13 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libwind0-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [47.8 kB]
Get:14 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libhx509-5-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [107 kB]
Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsqlite3-0 amd64 3.11.0-1ubuntu1.5 [398 kB]
Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libkrb5-26-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [202 kB]
Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libheimntlm0-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [15.1 kB]
Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgssapi3-heimdal amd64 1.7~git20150920+dfsg-4ubuntu1.16.04.1 [96.1 kB]
Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsasl2-modules-db amd64 2.1.26.dfsg1-14ubuntu0.2 [14.5 kB]
Get:20 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libsasl2-2 amd64 2.1.26.dfsg1-14ubuntu0.2 [48.7 kB]
Get:21 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libldap-2.4-2 amd64 2.4.42+dfsg-2ubuntu3.13 [159 kB]
Get:22 http://archive.ubuntu.com/ubuntu xenial/main amd64 libnfsidmap2 amd64 0.25-5 [32.2 kB]
Get:23 http://archive.ubuntu.com/ubuntu xenial/main amd64 libwrap0 amd64 7.6.q-25 [46.2 kB]
Get:24 http://archive.ubuntu.com/ubuntu xenial/main amd64 ucf all 3.0036 [52.9 kB]
Get:25 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libkrb5support0 amd64 1.13.2+dfsg-5ubuntu2.2 [31.2 kB]
Get:26 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libk5crypto3 amd64 1.13.2+dfsg-5ubuntu2.2 [81.2 kB]
Get:27 http://archive.ubuntu.com/ubuntu xenial/main amd64 libkeyutils1 amd64 1.5.9-8ubuntu1 [9904 B]
Get:28 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libkrb5-3 amd64 1.13.2+dfsg-5ubuntu2.2 [273 kB]
Get:29 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgssapi-krb5-2 amd64 1.13.2+dfsg-5ubuntu2.2 [120 kB]
Get:30 http://archive.ubuntu.com/ubuntu xenial/main amd64 keyutils amd64 1.5.9-8ubuntu1 [47.1 kB]
Get:31 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libevent-2.0-5 amd64 2.0.21-stable-2ubuntu0.16.04.1 [114 kB]
Get:32 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libtirpc1 amd64 0.2.5-1ubuntu0.1 [75.4 kB]
Get:33 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 rpcbind amd64 0.2.3-0.2ubuntu0.16.04.1 [40.7 kB]
Get:34 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 nfs-common amd64 1:1.2.8-9ubuntu12.3 [185 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 3759 kB in 7s (524 kB/s)
Selecting previously unselected package libgmp10:amd64.
(Reading database ... 4785 files and directories currently installed.)
Preparing to unpack .../libgmp10_2%3a6.1.0+dfsg-2_amd64.deb ...
Unpacking libgmp10:amd64 (2:6.1.0+dfsg-2) ...
Selecting previously unselected package libnettle6:amd64.
Preparing to unpack .../libnettle6_3.2-1ubuntu0.16.04.2_amd64.deb ...
Unpacking libnettle6:amd64 (3.2-1ubuntu0.16.04.2) ...
Selecting previously unselected package libhogweed4:amd64.
Preparing to unpack .../libhogweed4_3.2-1ubuntu0.16.04.2_amd64.deb ...
Unpacking libhogweed4:amd64 (3.2-1ubuntu0.16.04.2) ...
Selecting previously unselected package libidn11:amd64.
Preparing to unpack .../libidn11_1.32-3ubuntu1.2_amd64.deb ...
Unpacking libidn11:amd64 (1.32-3ubuntu1.2) ...
Selecting previously unselected package libffi6:amd64.
Preparing to unpack .../libffi6_3.2.1-4_amd64.deb ...
Unpacking libffi6:amd64 (3.2.1-4) ...
Selecting previously unselected package libp11-kit0:amd64.
Preparing to unpack .../libp11-kit0_0.23.2-5~ubuntu16.04.2_amd64.deb ...
Unpacking libp11-kit0:amd64 (0.23.2-5~ubuntu16.04.2) ...
Selecting previously unselected package libtasn1-6:amd64.
Preparing to unpack .../libtasn1-6_4.7-3ubuntu0.16.04.3_amd64.deb ...
Unpacking libtasn1-6:amd64 (4.7-3ubuntu0.16.04.3) ...
Selecting previously unselected package libgnutls30:amd64.
Preparing to unpack .../libgnutls30_3.4.10-4ubuntu1.8_amd64.deb ...
Unpacking libgnutls30:amd64 (3.4.10-4ubuntu1.8) ...
Selecting previously unselected package libroken18-heimdal:amd64.
Preparing to unpack .../libroken18-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libroken18-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libasn1-8-heimdal:amd64.
Preparing to unpack .../libasn1-8-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libasn1-8-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libhcrypto4-heimdal:amd64.
Preparing to unpack .../libhcrypto4-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libhcrypto4-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libheimbase1-heimdal:amd64.
Preparing to unpack .../libheimbase1-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libheimbase1-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libwind0-heimdal:amd64.
Preparing to unpack .../libwind0-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libwind0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libhx509-5-heimdal:amd64.
Preparing to unpack .../libhx509-5-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libhx509-5-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libsqlite3-0:amd64.
Preparing to unpack .../libsqlite3-0_3.11.0-1ubuntu1.5_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.11.0-1ubuntu1.5) ...
Selecting previously unselected package libkrb5-26-heimdal:amd64.
Preparing to unpack .../libkrb5-26-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libkrb5-26-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libheimntlm0-heimdal:amd64.
Preparing to unpack .../libheimntlm0-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libheimntlm0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libgssapi3-heimdal:amd64.
Preparing to unpack .../libgssapi3-heimdal_1.7~git20150920+dfsg-4ubuntu1.16.04.1_amd64.deb ...
Unpacking libgssapi3-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../libsasl2-modules-db_2.1.26.dfsg1-14ubuntu0.2_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.26.dfsg1-14ubuntu0.2) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../libsasl2-2_2.1.26.dfsg1-14ubuntu0.2_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.26.dfsg1-14ubuntu0.2) ...
Selecting previously unselected package libldap-2.4-2:amd64.
Preparing to unpack .../libldap-2.4-2_2.4.42+dfsg-2ubuntu3.13_amd64.deb ...
Unpacking libldap-2.4-2:amd64 (2.4.42+dfsg-2ubuntu3.13) ...
Selecting previously unselected package libnfsidmap2:amd64.
Preparing to unpack .../libnfsidmap2_0.25-5_amd64.deb ...
Unpacking libnfsidmap2:amd64 (0.25-5) ...
Selecting previously unselected package libwrap0:amd64.
Preparing to unpack .../libwrap0_7.6.q-25_amd64.deb ...
Unpacking libwrap0:amd64 (7.6.q-25) ...
Selecting previously unselected package ucf.
Preparing to unpack .../archives/ucf_3.0036_all.deb ...
Moving old data out of the way
Unpacking ucf (3.0036) ...
Selecting previously unselected package libkrb5support0:amd64.
Preparing to unpack .../libkrb5support0_1.13.2+dfsg-5ubuntu2.2_amd64.deb ...
Unpacking libkrb5support0:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Selecting previously unselected package libk5crypto3:amd64.
Preparing to unpack .../libk5crypto3_1.13.2+dfsg-5ubuntu2.2_amd64.deb ...
Unpacking libk5crypto3:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Selecting previously unselected package libkeyutils1:amd64.
Preparing to unpack .../libkeyutils1_1.5.9-8ubuntu1_amd64.deb ...
Unpacking libkeyutils1:amd64 (1.5.9-8ubuntu1) ...
Selecting previously unselected package libkrb5-3:amd64.
Preparing to unpack .../libkrb5-3_1.13.2+dfsg-5ubuntu2.2_amd64.deb ...
Unpacking libkrb5-3:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Selecting previously unselected package libgssapi-krb5-2:amd64.
Preparing to unpack .../libgssapi-krb5-2_1.13.2+dfsg-5ubuntu2.2_amd64.deb ...
Unpacking libgssapi-krb5-2:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Selecting previously unselected package keyutils.
Preparing to unpack .../keyutils_1.5.9-8ubuntu1_amd64.deb ...
Unpacking keyutils (1.5.9-8ubuntu1) ...
Selecting previously unselected package libevent-2.0-5:amd64.
Preparing to unpack .../libevent-2.0-5_2.0.21-stable-2ubuntu0.16.04.1_amd64.deb ...
Unpacking libevent-2.0-5:amd64 (2.0.21-stable-2ubuntu0.16.04.1) ...
Selecting previously unselected package libtirpc1:amd64.
Preparing to unpack .../libtirpc1_0.2.5-1ubuntu0.1_amd64.deb ...
Unpacking libtirpc1:amd64 (0.2.5-1ubuntu0.1) ...
Selecting previously unselected package rpcbind.
Preparing to unpack .../rpcbind_0.2.3-0.2ubuntu0.16.04.1_amd64.deb ...
Unpacking rpcbind (0.2.3-0.2ubuntu0.16.04.1) ...
Selecting previously unselected package nfs-common.
Preparing to unpack .../nfs-common_1%3a1.2.8-9ubuntu12.3_amd64.deb ...
Unpacking nfs-common (1:1.2.8-9ubuntu12.3) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Processing triggers for systemd (229-4ubuntu21.31) ...
Setting up libgmp10:amd64 (2:6.1.0+dfsg-2) ...
Setting up libnettle6:amd64 (3.2-1ubuntu0.16.04.2) ...
Setting up libhogweed4:amd64 (3.2-1ubuntu0.16.04.2) ...
Setting up libidn11:amd64 (1.32-3ubuntu1.2) ...
Setting up libffi6:amd64 (3.2.1-4) ...
Setting up libp11-kit0:amd64 (0.23.2-5~ubuntu16.04.2) ...
Setting up libtasn1-6:amd64 (4.7-3ubuntu0.16.04.3) ...
Setting up libgnutls30:amd64 (3.4.10-4ubuntu1.8) ...
Setting up libroken18-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libasn1-8-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libhcrypto4-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libheimbase1-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libwind0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libhx509-5-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libsqlite3-0:amd64 (3.11.0-1ubuntu1.5) ...
Setting up libkrb5-26-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libheimntlm0-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libgssapi3-heimdal:amd64 (1.7~git20150920+dfsg-4ubuntu1.16.04.1) ...
Setting up libsasl2-modules-db:amd64 (2.1.26.dfsg1-14ubuntu0.2) ...
Setting up libsasl2-2:amd64 (2.1.26.dfsg1-14ubuntu0.2) ...
Setting up libldap-2.4-2:amd64 (2.4.42+dfsg-2ubuntu3.13) ...
Setting up libnfsidmap2:amd64 (0.25-5) ...
Setting up libwrap0:amd64 (7.6.q-25) ...
Setting up ucf (3.0036) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up libkrb5support0:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Setting up libk5crypto3:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Setting up libkeyutils1:amd64 (1.5.9-8ubuntu1) ...
Setting up libkrb5-3:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Setting up libgssapi-krb5-2:amd64 (1.13.2+dfsg-5ubuntu2.2) ...
Setting up keyutils (1.5.9-8ubuntu1) ...
Setting up libevent-2.0-5:amd64 (2.0.21-stable-2ubuntu0.16.04.1) ...
Setting up libtirpc1:amd64 (0.2.5-1ubuntu0.1) ...
Setting up rpcbind (0.2.3-0.2ubuntu0.16.04.1) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Setting up nfs-common (1:1.2.8-9ubuntu12.3) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype

Creating config file /etc/idmapd.conf with new version
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype

Creating config file /etc/default/nfs-common with new version
Adding system user `statd' (UID 105) ...
Adding new user `statd' (UID 105) with group `nogroup' ...
Not creating home directory `/var/lib/nfs'.
invoke-rc.d: unknown initscript, /etc/init.d/gssd not found.
invoke-rc.d: could not determine current runlevel
invoke-rc.d: unknown initscript, /etc/init.d/idmapd not found.
invoke-rc.d: could not determine current runlevel
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Processing triggers for systemd (229-4ubuntu21.31) ...
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  udev
0 upgraded, 1 newly installed, 0 to remove and 5 not upgraded.
Need to get 995 kB of archives.
After this operation, 6895 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 udev amd64 229-4ubuntu21.31 [995 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 995 kB in 2s (338 kB/s)
Selecting previously unselected package udev.
(Reading database ... 5138 files and directories currently installed.)
Preparing to unpack .../udev_229-4ubuntu21.31_amd64.deb ...
Unpacking udev (229-4ubuntu21.31) ...
Processing triggers for systemd (229-4ubuntu21.31) ...
Setting up udev (229-4ubuntu21.31) ...
Adding group `input' (GID 106) ...
Done.
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Processing triggers for systemd (229-4ubuntu21.31) ...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libapt-pkg5.0
Suggested packages:
  aptitude | synaptic | wajig dpkg-dev apt-doc python-apt
The following packages will be upgraded:
  apt libapt-pkg5.0
2 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Need to get 1822 kB of archives.
After this operation, 70.7 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libapt-pkg5.0 amd64 1.2.35 [715 kB]
Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt amd64 1.2.35 [1107 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 1822 kB in 2s (620 kB/s)
(Reading database ... 5243 files and directories currently installed.)
Preparing to unpack .../libapt-pkg5.0_1.2.35_amd64.deb ...
Unpacking libapt-pkg5.0:amd64 (1.2.35) over (1.2.32ubuntu0.2) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Setting up libapt-pkg5.0:amd64 (1.2.35) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
(Reading database ... 5243 files and directories currently installed.)
Preparing to unpack .../archives/apt_1.2.35_amd64.deb ...
Unpacking apt (1.2.35) over (1.2.32ubuntu0.2) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Setting up apt (1.2.35) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libreadline5 libssl1.0.0 openssl
Suggested packages:
  xfsdump acl attr quota
The following NEW packages will be installed:
  ca-certificates libreadline5 libssl1.0.0 openssl xfsprogs
0 upgraded, 5 newly installed, 0 to remove and 3 not upgraded.
Need to get 2418 kB of archives.
After this operation, 8576 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libssl1.0.0 amd64 1.0.2g-1ubuntu4.19 [1082 kB]
Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 openssl amd64 1.0.2g-1ubuntu4.19 [492 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 ca-certificates all 20210119~16.04.1 [148 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libreadline5 amd64 5.2+dfsg-3build1 [99.5 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 xfsprogs amd64 4.3.0+nmu1ubuntu1.1 [597 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 2418 kB in 2s (860 kB/s)
Selecting previously unselected package libssl1.0.0:amd64.
(Reading database ... 5243 files and directories currently installed.)
Preparing to unpack .../libssl1.0.0_1.0.2g-1ubuntu4.19_amd64.deb ...
Unpacking libssl1.0.0:amd64 (1.0.2g-1ubuntu4.19) ...
Selecting previously unselected package openssl.
Preparing to unpack .../openssl_1.0.2g-1ubuntu4.19_amd64.deb ...
Unpacking openssl (1.0.2g-1ubuntu4.19) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../ca-certificates_20210119~16.04.1_all.deb ...
Unpacking ca-certificates (20210119~16.04.1) ...
Selecting previously unselected package libreadline5:amd64.
Preparing to unpack .../libreadline5_5.2+dfsg-3build1_amd64.deb ...
Unpacking libreadline5:amd64 (5.2+dfsg-3build1) ...
Selecting previously unselected package xfsprogs.
Preparing to unpack .../xfsprogs_4.3.0+nmu1ubuntu1.1_amd64.deb ...
Unpacking xfsprogs (4.3.0+nmu1ubuntu1.1) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Setting up libssl1.0.0:amd64 (1.0.2g-1ubuntu4.19) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up openssl (1.0.2g-1ubuntu4.19) ...
Setting up ca-certificates (20210119~16.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up libreadline5:amd64 (5.2+dfsg-3build1) ...
Setting up xfsprogs (4.3.0+nmu1ubuntu1.1) ...
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
Processing triggers for ca-certificates (20210119~16.04.1) ...
Updating certificates in /etc/ssl/certs...
129 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages will be upgraded:
  libc-bin libc6 multiarch-support
3 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 3225 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libc6 amd64 2.23-0ubuntu11.3 [2590 kB]
Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 libc-bin amd64 2.23-0ubuntu11.3 [629 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 multiarch-support amd64 2.23-0ubuntu11.3 [6830 B]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 3225 kB in 4s (649 kB/s)
(Reading database ... 5576 files and directories currently installed.)
Preparing to unpack .../libc6_2.23-0ubuntu11.3_amd64.deb ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Unpacking libc6:amd64 (2.23-0ubuntu11.3) over (2.23-0ubuntu11.2) ...
Setting up libc6:amd64 (2.23-0ubuntu11.3) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Processing triggers for libc-bin (2.23-0ubuntu11.2) ...
(Reading database ... 5576 files and directories currently installed.)
Preparing to unpack .../libc-bin_2.23-0ubuntu11.3_amd64.deb ...
Unpacking libc-bin (2.23-0ubuntu11.3) over (2.23-0ubuntu11.2) ...
Setting up libc-bin (2.23-0ubuntu11.3) ...
(Reading database ... 5576 files and directories currently installed.)
Preparing to unpack .../multiarch-support_2.23-0ubuntu11.3_amd64.deb ...
Unpacking multiarch-support (2.23-0ubuntu11.3) over (2.23-0ubuntu11.2) ...
Setting up multiarch-support (2.23-0ubuntu11.3) ...
Removing intermediate container 49daee8ffc6b
 ---> bdde364831d8
Step 15/19 : RUN mkdir -p /home/ibm-csi-drivers/
 ---> Running in 1e8dad50bf84
Removing intermediate container 1e8dad50bf84
 ---> f45ca033294b
Step 16/19 : ADD ibm-vpc-block-csi-driver /home/ibm-csi-drivers
 ---> e97f8f96fddd
Step 17/19 : RUN chmod +x /home/ibm-csi-drivers/ibm-vpc-block-csi-driver
 ---> Running in 33fec6e23147
Removing intermediate container 33fec6e23147
 ---> 6cbd15425d91
Step 18/19 : USER 2121:2121
 ---> Running in 1c0b815f927b
Removing intermediate container 1c0b815f927b
 ---> cfe48c4d5971
Step 19/19 : ENTRYPOINT ["/home/ibm-csi-drivers/ibm-vpc-block-csi-driver"]
 ---> Running in 27327d833ef5
Removing intermediate container 27327d833ef5
 ---> a5395ed560cd
[Warning] One or more build-args [PROXY_IMAGE_URL] were not consumed
Successfully built a5395ed560cd
Successfully tagged contsto2/ibm-vpc-block-csi-driver:latest-amd64
docker tag contsto2/ibm-vpc-block-csi-driver:latest-amd64 contsto2/ibm-vpc-block-csi-driver:latest
```